### PR TITLE
⚡ Bolt: Add missing database indexes to improve query performance

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -1,0 +1,3 @@
+## 2024-06-25 - [Missing DB Indexes in PHP application]
+**Learning:** In traditional PHP/MySQL applications, SQL scripts used for initial schema definitions (like `db/disc.sql`) often lack necessary indexes for fields frequently queried or used in complex JOINs (like `graph`, `dimension`, `value` in the `results` table, and `d`, `i`, `s`, `c` in `pattern_map`).
+**Action:** When optimizing traditional LAMP stack apps, inspect the SQL schema definition files for missing `PRIMARY KEY` and `KEY` definitions on columns heavily used in `WHERE` and `JOIN` clauses to prevent O(N) full table scans.

--- a/db/disc.sql
+++ b/db/disc.sql
@@ -134,7 +134,9 @@ CREATE TABLE IF NOT EXISTS results
 	value INT NOT NULL,
 	segment INT NOT NULL,
 	graph TINYINT(1) NOT NULL,
-	PRIMARY KEY(id)
+	PRIMARY KEY(id),
+	-- Bolt optimization: Add database index on frequently queried fields
+	KEY idx_graph_dim_val (graph, dimension, value)
 ) ENGINE MyISAM DEFAULT CHARSET=utf8;
 INSERT INTO results VALUES 
 (1,'D',28,27,7,1),
@@ -347,7 +349,9 @@ CREATE TABLE IF NOT EXISTS pattern_map
   i TINYINT(1) NOT NULL,
   s TINYINT(1) NOT NULL,
   c TINYINT(1) NOT NULL,
-  pattern TINYINT(1) NOT NULL
+  pattern TINYINT(1) NOT NULL,
+  -- Bolt optimization: Add database index on frequently queried fields for JOINs
+  PRIMARY KEY (d, i, s, c)
 ) ENGINE MyISAM;
 INSERT INTO pattern_map VALUES 
 (7,7,7,7,14),


### PR DESCRIPTION
💡 **What:** Added a `PRIMARY KEY` to the `pattern_map` table (columns `d`, `i`, `s`, `c`) and a compound `KEY` to the `results` table (columns `graph`, `dimension`, `value`) in `db/disc.sql`.

🎯 **Why:** The `result.php` file executes a complex `JOIN` query that filters the `results` table by `graph`, `dimension`, and `value`, and then joins the result with the `pattern_map` table using the `d`, `i`, `s`, and `c` columns. Without these indexes, MySQL performs full table scans (O(n)), significantly slowing down query execution.

📊 **Impact:** Reduces database query latency from O(n) table scans to O(1) or O(log n) index lookups. The `pattern_map` table has 1421 rows and `results` has 112 rows, so this ensures lookups remain extremely fast even if the dataset grows.

🔬 **Measurement:** You can verify the improvement by running an `EXPLAIN` query on the SQL found in `result.php`. Before the change, the `type` column in the EXPLAIN output shows `ALL` (full table scan). After this change, it will show `ref` or `eq_ref` (index lookup).

---
*PR created automatically by Jules for task [14658416582306412894](https://jules.google.com/task/14658416582306412894) started by @cahyadsn*