### PR TITLE
🔒 Fix missing input type validation in result.php

### DIFF
--- a/result.php
+++ b/result.php
@@ -42,7 +42,7 @@ UPDATED DATE : 2019-07-14
   </head>
   <body>
 <?php
-if(isset($_POST['m']) && isset($_POST['l'])){
+if(isset($_POST['m']) && isset($_POST['l']) && is_array($_POST['m']) && is_array($_POST['l'])){
   $most=array_count_values($_POST['m']);
   $least=array_count_values($_POST['l']);
   $result=array();


### PR DESCRIPTION
🎯 **What:** Missing Input Type Validation vulnerability in `result.php` where POST parameters were passed directly to `array_count_values()` without confirming they were arrays.
⚠️ **Risk:** An attacker could submit strings or non-arrays for POST variables 'm' and 'l', leading to `TypeError` exceptions or application crashes (Denial of Service).
🛡️ **Solution:** Added `is_array()` checks for `$_POST['m']` and `$_POST['l']` before processing the input.

---
*PR created automatically by Jules for task [8567561927649667271](https://jules.google.com/task/8567561927649667271) started by @cahyadsn*