### PR TITLE
🔒 Fix insecure default database password

### DIFF
--- a/db.php
+++ b/db.php
@@ -2,7 +2,10 @@
 //-- database configuration
 $dbhost = getenv('DB_HOST') ?: 'localhost';
 $dbuser = getenv('DB_USER') ?: 'root';
-$dbpass = getenv('DB_PASS') ?: '';
+$dbpass = getenv('DB_PASS');
+if ($dbpass === false) {
+    throw new Exception('DB_PASS environment variable is required.');
+}
 $dbname = getenv('DB_NAME') ?: 'test';
 
 //-- database connection

--- a/tests/test_db_pass.php
+++ b/tests/test_db_pass.php
@@ -1,0 +1,49 @@
+<?php
+
+mysqli_report(MYSQLI_REPORT_OFF);
+
+echo "Running security fix tests for db.php...\n";
+
+// Test 1: DB_PASS is missing
+putenv('DB_PASS'); // Unset DB_PASS
+
+$exceptionThrown = false;
+try {
+    @include __DIR__ . '/../db.php';
+} catch (Exception $e) {
+    if ($e->getMessage() === 'DB_PASS environment variable is required.') {
+        $exceptionThrown = true;
+    } else {
+        echo "FAIL: Unexpected exception: " . $e->getMessage() . "\n";
+        exit(1);
+    }
+}
+
+if (!$exceptionThrown) {
+    echo "FAIL: Expected exception was not thrown when DB_PASS is missing.\n";
+    exit(1);
+} else {
+    echo "PASS: Exception thrown when DB_PASS is missing.\n";
+}
+
+// Test 2: DB_PASS is set
+putenv('DB_PASS=securepassword');
+
+try {
+    @include __DIR__ . '/../db.php';
+    echo "PASS: No exception thrown when DB_PASS is provided.\n";
+} catch (Exception $e) {
+    if ($e->getMessage() === 'DB_PASS environment variable is required.') {
+        echo "FAIL: Exception thrown even when DB_PASS is provided.\n";
+        exit(1);
+    } else {
+        // Other exceptions (like connection issues) might be acceptable if they aren't the missing DB_PASS error,
+        // but typically db.php just warns on connection failure if mysqli_report is off, or returns a mysqli object with connect_errno.
+        echo "PASS: Got different exception/error (expected due to no DB), but not the DB_PASS one.\n";
+    }
+} catch (Error $e) {
+    // Catch fatal errors if any
+}
+
+echo "All tests passed.\n";
+exit(0);


### PR DESCRIPTION
🎯 **What:** The vulnerability fixed
The database connection configuration in `db.php` fell back to an insecure default (empty string) for the database password if the `DB_PASS` environment variable was missing. This was removed, and instead an Exception is now thrown when the variable is not set.

⚠️ **Risk:** The potential impact if left unfixed
Deployments missing the `DB_PASS` environment variable could expose the database using root access with no password, leading to full data compromise.

🛡️ **Solution:** How the fix addresses the vulnerability
Require `DB_PASS` to be set in the environment by explicitly checking if `getenv('DB_PASS')` returns `false`. If it does, throw an `Exception` to fail fast and prevent unauthorized access due to missing credentials.

---
*PR created automatically by Jules for task [11064418854310378799](https://jules.google.com/task/11064418854310378799) started by @cahyadsn*