### PR TITLE
🧹 Remove unused $terms variable in index.php

### DIFF
--- a/index.php
+++ b/index.php
@@ -11,7 +11,6 @@ $sql='SELECT * FROM personalities ORDER BY no ASC';
 $result=$db->query($sql);
 $data=array();
 while($row=$result->fetch_object()) $data[]=$row;
-$terms=json_encode($data);
 $show_mark	= 0;	//<-- show 1 or hide 0 the marker
 $cols  		= 4;	//<-- number of columns
 $rows 		= count($data)/(4*$cols);


### PR DESCRIPTION
🎯 **What:** Removed the unused variable assignment `$terms=json_encode($data);` in `index.php`.

💡 **Why:** This improves code maintainability by eliminating dead code and an unnecessary variable allocation. The `json_encode` execution had no side effects, making it safe to remove. This reduces clutter and confusion for future developers reading the file.

✅ **Verification:** Verified that PHP syntax is correct using `php -l index.php`. Ran the existing test suite (specifically testing security fixes, db connections, missing post values) to confirm that no regressions were introduced. Note: A pre-existing test failure in `test_db.php` is expected due to earlier security changes requiring `DB_PASS`. Code review also verified this was completely safe.

✨ **Result:** Cleaned up `index.php` without altering its behavior, successfully resolving the code health issue.

---
*PR created automatically by Jules for task [8533091751893363115](https://jules.google.com/task/8533091751893363115) started by @cahyadsn*