### PR TITLE
🧹 Remove error suppression operator (@) in index.php

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,4 @@
 /screenshot/
 /.kiro/
+vendor/
+.phpunit.result.cache

--- a/index.php
+++ b/index.php
@@ -9,10 +9,12 @@ require_once 'db.php';
 
 $cache_file = __DIR__ . '/personalities_cache.json';
 $data = null;
-if (file_exists($cache_file)) {
-    $file_content = @file_get_contents($cache_file);
+if (file_exists($cache_file) && is_readable($cache_file)) {
+    $file_content = file_get_contents($cache_file);
     if ($file_content !== false) {
         $data = json_decode($file_content);
+    } else {
+        error_log("Failed to read cache file: $cache_file");
     }
 }
 
@@ -24,7 +26,9 @@ if ($data === null || !is_array($data)) {
     while($row=$result->fetch_object()) $data[]=$row;
 
     // Save to cache for future requests using LOCK_EX for safety during concurrent writes
-    @file_put_contents($cache_file, json_encode($data), LOCK_EX);
+    if (file_put_contents($cache_file, json_encode($data), LOCK_EX) === false) {
+        error_log("Failed to write to cache file: $cache_file");
+    }
 }
 
 $show_mark	= 0;	//<-- show 1 or hide 0 the marker


### PR DESCRIPTION
### 🎯 What
Removed the error suppression operator (`@`) used with `file_get_contents()` and `file_put_contents()` in `index.php`. Added `is_readable()` checks before reading the cache file, and proper error logging with `error_log()` when reading or writing fails. Added `.phpunit.result.cache` and `vendor/` to `.gitignore`.

### 💡 Why
Using the error suppression operator (`@`) hides potential issues such as permission errors or disk space issues. Removing it and implementing explicit error handling improves code debuggability, making it easier to diagnose issues when the file cannot be read or written.

### ✅ Verification
1.  **Syntax Check:** Ran `php -l index.php` (No syntax errors detected).
2.  **Custom Tests:** Executed the ad-hoc test suite loop `for t in tests/*.php; do if [[ "$t" != *"DiscTest"* ]]; then php "$t"; fi; done` (All passed).
3.  **PHPUnit Tests:** Executed `vendor/bin/phpunit tests/DiscTest.php` (All 6 tests, 28 assertions passed).

### ✨ Result
The application now handles file system operations gracefully without silencing errors, resulting in a cleaner and more maintainable codebase that will log issues cleanly instead of failing silently.

---
*PR created automatically by Jules for task [2691720940006399251](https://jules.google.com/task/2691720940006399251) started by @cahyadsn*