### PR TITLE
🧹 [code health improvement: Fix variable shadowing of $result in result.php]

### DIFF
--- a/result.php
+++ b/result.php
@@ -64,8 +64,8 @@ if(isset($_POST['m']) && isset($_POST['l']) && is_array($_POST['m']) && is_array
 		  AND a.i = (SELECT segment FROM results WHERE graph=3 AND dimension='I' AND value=".$result['I']['change']." LIMIT 1)
 		  AND a.s = (SELECT segment FROM results WHERE graph=3 AND dimension='S' AND value=".$result['S']['change']." LIMIT 1)
 		  AND a.c = (SELECT segment FROM results WHERE graph=3 AND dimension='C' AND value=".$result['C']['change']." LIMIT 1)";
-	$result=$db->query($sql);
-	$data=(isset($result)&& !empty($result))?$result->fetch_object():'';
+	$db_result=$db->query($sql);
+	$data=(isset($db_result)&& !empty($db_result))?$db_result->fetch_object():'';
 	//-- if empty result found, get default result
 	if(!isset($data->name)){
 	    $sql="
@@ -76,8 +76,8 @@ if(isset($_POST['m']) && isset($_POST['l']) && is_array($_POST['m']) && is_array
 			  AND a.i = (SELECT segment FROM results WHERE graph=3 AND dimension='I' AND value=14 LIMIT 1)
 			  AND a.s = (SELECT segment FROM results WHERE graph=3 AND dimension='S' AND value=15 LIMIT 1)
 			  AND a.c = (SELECT segment FROM results WHERE graph=3 AND dimension='C' AND value=14 LIMIT 1)";
-		$result=$db->query($sql);
-		$data=(isset($result)&& !empty($result))?$result->fetch_object():throw new Exception('Data not found, check your database');
+		$db_result=$db->query($sql);
+		$data=(isset($db_result)&& !empty($db_result))?$db_result->fetch_object():throw new Exception('Data not found, check your database');
 	}
     ?>
     <div>


### PR DESCRIPTION
🎯 **What:** Fixed a variable shadowing issue in `result.php` where the database query result was assigned to `$result`, which overwrote the `$result` array that was holding the calculated DISC scores.

💡 **Why:** This improves maintainability and readability by avoiding variable reuse/shadowing, which can lead to subtle bugs or confusion when reasoning about the code, especially if the `$result` array needs to be referenced later in the script.

✅ **Verification:** 
- Used `php -l result.php` to verify no syntax errors were introduced.
- Ran the ad-hoc test suite (`for t in tests/test_*.php; do php "$t"; done`) to confirm that all tests passed and no regressions were introduced.

✨ **Result:** The code is cleaner, more robust, and the variable names accurately reflect their contents (`$db_result` for the database object and `$result` for the score array).

---
*PR created automatically by Jules for task [1708005632888979797](https://jules.google.com/task/1708005632888979797) started by @cahyadsn*