### PR TITLE
🧪 [Add test for database connection failure]

### DIFF
--- a/tests/test_db_connection_failure.php
+++ b/tests/test_db_connection_failure.php
@@ -1,0 +1,34 @@
+<?php
+
+echo "Running DB connection failure test...\n";
+
+// Set invalid host to simulate connection error
+putenv('DB_HOST=invalid_host_12345');
+putenv('DB_USER=test');
+putenv('DB_PASS=test');
+putenv('DB_NAME=test');
+
+$exceptionThrown = false;
+try {
+    // Suppress warning using @ to avoid noise, but catch the exception
+    @include __DIR__ . '/../db.php';
+
+    // In some older PHP versions or configs, mysqli constructor might not throw but set connect_error
+    if (isset($db) && $db->connect_error) {
+        $exceptionThrown = true;
+    }
+} catch (mysqli_sql_exception $e) {
+    $exceptionThrown = true;
+} catch (Exception $e) {
+    $exceptionThrown = true;
+}
+
+if (!$exceptionThrown) {
+    echo "FAIL: Expected exception or connection error when DB host is invalid.\n";
+    exit(1);
+} else {
+    echo "PASS: Caught connection error properly.\n";
+}
+
+echo "All tests passed.\n";
+exit(0);


### PR DESCRIPTION
🎯 **What:** 
Added a test to explicitly verify the behavior of `db.php` when a database connection fails (e.g., due to an invalid database host). This fills a testing gap where connection exceptions were not validated.

📊 **Coverage:** 
- The new test `tests/test_db_connection_failure.php` covers the scenario where `DB_HOST` is invalid.
- It asserts that the expected `mysqli_sql_exception` (or a `connect_error` property on older configurations) is correctly produced when `new mysqli()` fails to establish a connection.

✨ **Result:** 
- Improved test coverage for database initialization errors.
- Ensures the application gracefully handles or correctly exposes connection failures, providing a safety net against regressions in connection logic.

---
*PR created automatically by Jules for task [11450822049226588490](https://jules.google.com/task/11450822049226588490) started by @cahyadsn*