### PR TITLE
🔒 Fix SQL Injection vulnerability in result.php

### DIFF
--- a/result.php
+++ b/result.php
@@ -60,11 +60,14 @@ if(isset($_POST['m']) && isset($_POST['l']) && is_array($_POST['m']) && is_array
         SELECT a.*, c.*
 		FROM pattern_map a
 		JOIN patterns c ON c.id=a.pattern
-		WHERE a.d = (SELECT segment FROM results WHERE graph=3 AND dimension='D' AND value=".$result['D']['change']." LIMIT 1)
-		  AND a.i = (SELECT segment FROM results WHERE graph=3 AND dimension='I' AND value=".$result['I']['change']." LIMIT 1)
-		  AND a.s = (SELECT segment FROM results WHERE graph=3 AND dimension='S' AND value=".$result['S']['change']." LIMIT 1)
-		  AND a.c = (SELECT segment FROM results WHERE graph=3 AND dimension='C' AND value=".$result['C']['change']." LIMIT 1)";
-	$db_result=$db->query($sql);
+		WHERE a.d = (SELECT segment FROM results WHERE graph=3 AND dimension='D' AND value=? LIMIT 1)
+		  AND a.i = (SELECT segment FROM results WHERE graph=3 AND dimension='I' AND value=? LIMIT 1)
+		  AND a.s = (SELECT segment FROM results WHERE graph=3 AND dimension='S' AND value=? LIMIT 1)
+		  AND a.c = (SELECT segment FROM results WHERE graph=3 AND dimension='C' AND value=? LIMIT 1)";
+	$stmt = $db->prepare($sql);
+	$stmt->bind_param("iiii", $result['D']['change'], $result['I']['change'], $result['S']['change'], $result['C']['change']);
+	$stmt->execute();
+	$db_result=$stmt->get_result();
 	$data=(isset($db_result)&& !empty($db_result))?$db_result->fetch_object():'';
 	//-- if empty result found, get default result
 	if(!isset($data->name)){

--- a/tests/test_sqli_fix.php
+++ b/tests/test_sqli_fix.php
@@ -1,0 +1,30 @@
+<?php
+$content = file_get_contents(__DIR__ . '/../result.php');
+$failed = false;
+
+// Check if string concatenation is still used in the SQL query
+if (preg_match('/value="\.\$result\[\'D\'\]\[\'change\'\]\." LIMIT 1\)/', $content) ||
+    preg_match('/value="\.\$result\[\'I\'\]\[\'change\'\]\." LIMIT 1\)/', $content) ||
+    preg_match('/value="\.\$result\[\'S\'\]\[\'change\'\]\." LIMIT 1\)/', $content) ||
+    preg_match('/value="\.\$result\[\'C\'\]\[\'change\'\]\." LIMIT 1\)/', $content)) {
+    echo "FAIL: SQL concatenation with \$result array still found.\n";
+    $failed = true;
+}
+
+// Check if bind_param is used
+if (!preg_match('/\$stmt->bind_param\("iiii", \$result\[\'D\'\]\[\'change\'\], \$result\[\'I\'\]\[\'change\'\], \$result\[\'S\'\]\[\'change\'\], \$result\[\'C\'\]\[\'change\'\]\);/', $content)) {
+    echo "FAIL: bind_param is missing or incorrect.\n";
+    $failed = true;
+}
+
+// Check if execute is used
+if (!preg_match('/\$stmt->execute\(\);/', $content)) {
+    echo "FAIL: execute() is missing.\n";
+    $failed = true;
+}
+
+if ($failed) {
+    exit(1);
+}
+echo "PASS: SQLi fix implemented correctly with prepared statements.\n";
+exit(0);


### PR DESCRIPTION
🎯 **What:** Fixed an SQL injection vulnerability in `result.php` where data was directly interpolated into a database query.

⚠️ **Risk:** The values `$result['D']['change']` (and others) are dynamically calculated from user input in `$_POST['m']` and `$_POST['l']`. While PHP `is_scalar` and `array_count_values` provide some limitations, improper manipulation or edge cases involving string inputs could allow an attacker to alter the logic of the SQL query, leading to SQL injection.

🛡️ **Solution:** Modified the database query execution to utilize PHP's `mysqli` prepared statements. The concatenated variables in the SQL string were replaced with `?` placeholders. The parameters are now correctly bound using `$stmt->bind_param('iiii', ...)` which securely casts the inputs and safely structures the query, eliminating the risk of SQL injection. Also added a static analysis test to ensure prepared statements are maintained in this query in the future.

---
*PR created automatically by Jules for task [5714357395113551187](https://jules.google.com/task/5714357395113551187) started by @cahyadsn*