### PR TITLE
🧹 Fix duplicate SQL query in result.php

### DIFF
--- a/result.php
+++ b/result.php
@@ -65,21 +65,22 @@ if(isset($_POST['m']) && isset($_POST['l']) && is_array($_POST['m']) && is_array
 		  AND a.s = (SELECT segment FROM results WHERE graph=3 AND dimension='S' AND value=? LIMIT 1)
 		  AND a.c = (SELECT segment FROM results WHERE graph=3 AND dimension='C' AND value=? LIMIT 1)";
 	$stmt = $db->prepare($sql);
-	$stmt->bind_param("iiii", $result['D']['change'], $result['I']['change'], $result['S']['change'], $result['C']['change']);
+	$val_d = $result['D']['change'];
+	$val_i = $result['I']['change'];
+	$val_s = $result['S']['change'];
+	$val_c = $result['C']['change'];
+	$stmt->bind_param("iiii", $val_d, $val_i, $val_s, $val_c);
 	$stmt->execute();
 	$db_result=$stmt->get_result();
 	$data=(isset($db_result)&& !empty($db_result))?$db_result->fetch_object():'';
 	//-- if empty result found, get default result
 	if(!isset($data->name)){
-	    $sql="
-		SELECT a.*, c.*
-			FROM pattern_map a
-			JOIN patterns c ON c.id=a.pattern
-			WHERE a.d = (SELECT segment FROM results WHERE graph=3 AND dimension='D' AND value=15 LIMIT 1)
-			  AND a.i = (SELECT segment FROM results WHERE graph=3 AND dimension='I' AND value=14 LIMIT 1)
-			  AND a.s = (SELECT segment FROM results WHERE graph=3 AND dimension='S' AND value=15 LIMIT 1)
-			  AND a.c = (SELECT segment FROM results WHERE graph=3 AND dimension='C' AND value=14 LIMIT 1)";
-		$db_result=$db->query($sql);
+		$val_d = 15;
+		$val_i = 14;
+		$val_s = 15;
+		$val_c = 14;
+		$stmt->execute();
+		$db_result=$stmt->get_result();
 		$data=(isset($db_result)&& !empty($db_result))?$db_result->fetch_object():throw new Exception('Data not found, check your database');
 	}
     ?>

--- a/tests/test_sqli_fix.php
+++ b/tests/test_sqli_fix.php
@@ -12,7 +12,8 @@ if (preg_match('/value="\.\$result\[\'D\'\]\[\'change\'\]\." LIMIT 1\)/', $conte
 }
 
 // Check if bind_param is used
-if (!preg_match('/\$stmt->bind_param\("iiii", \$result\[\'D\'\]\[\'change\'\], \$result\[\'I\'\]\[\'change\'\], \$result\[\'S\'\]\[\'change\'\], \$result\[\'C\'\]\[\'change\'\]\);/', $content)) {
+if (!preg_match('/\$stmt->bind_param\("iiii", \$val_d, \$val_i, \$val_s, \$val_c\);/', $content) &&
+    !preg_match('/\$stmt->bind_param\("iiii", \$result\[\'D\'\]\[\'change\'\], \$result\[\'I\'\]\[\'change\'\], \$result\[\'S\'\]\[\'change\'\], \$result\[\'C\'\]\[\'change\'\]\);/', $content)) {
     echo "FAIL: bind_param is missing or incorrect.\n";
     $failed = true;
 }


### PR DESCRIPTION
🎯 **What:** Removed duplicate SQL query block in `result.php`.
💡 **Why:** Refactoring code to reuse a prepared statement prevents logic fragmentation and makes the code cleaner. Using the pass-by-reference mechanism of `bind_param` allows us to simply reassign the bound variables and execute again for the default fallback values.
✅ **Verification:** Verified by checking there were no syntax errors (`php -l result.php`), and running the full ad-hoc test suite (`tests/test_*.php`) which passed successfully. Updated existing mock regex test (`test_sqli_fix.php`) to accept the new bounds param variables.
✨ **Result:** A more readable query execution block that respects the DRY principle.

---
*PR created automatically by Jules for task [15285312998397087940](https://jules.google.com/task/15285312998397087940) started by @cahyadsn*