### PR TITLE
🧹 Extract inline CSS to an external stylesheet

### DIFF
--- a/assets/style.css
+++ b/assets/style.css
@@ -1,0 +1,27 @@
+body,table {font-family: verdana,arial,sans-serif;font-size: 1em;}
+input {background-color: #eee;line-height:1.5em;}
+thead {background-color: #666;color: #fff;line-height: 2em; padding:0.2em;}
+tfoot {background-color: #999;color: #fff;}
+td {padding:0.2em;}
+caption {font-size: 2em;}
+input[type=radio]{border-radius: 0;width:2.2em;height:2.2em;}
+.btn {background-color: #eee;line-height:2em;padding:0.1em 0.6em;
+	   margin:0.2em;font-size:1.5em;font-weight:bold;
+	   border-radius: 0.3em;}
+.dark {background-color: #eee;}
+.first {border-top: solid 0.2em #000; }
+.badge { position:relative;line-height: 3em;border:solid #999 1px;
+	   text-align: center;font-size: 2em;}
+.badge[data-badge]:after {
+   content:attr(data-badge);
+   position:absolute;
+   top:1px;
+   left:1px;
+   font-size:.7em;
+   background:#9af;
+   color:white;
+   width:18px;height:18px;
+   text-align:center;
+   line-height:18px;
+   box-shadow:0 0 1px #333;
+  }

--- a/index.php
+++ b/index.php
@@ -48,35 +48,7 @@ $rows 		= count($data)/(4*$cols);
 <html>
   <head>
     <title>DISC Personality Test</title>
-    <style>
-    body,table {font-family: verdana,arial,sans-serif;font-size: 1em;}
-    input {background-color: #eee;line-height:1.5em;}
-    thead {background-color: #666;color: #fff;line-height: 2em; padding:0.2em;}
-    tfoot {background-color: #999;color: #fff;}
-    td {padding:0.2em;}
-    caption {font-size: 2em;}
-    input[type=radio]{border-radius: 0;width:2.2em;height:2.2em;}
-    .btn {background-color: #eee;line-height:2em;padding:0.1em 0.6em;
-    	   margin:0.2em;font-size:1.5em;font-weight:bold;
-    	   border-radius: 0.3em;}
-    .dark {background-color: #eee;}
-    .first {border-top: solid 0.2em #000; }
-    .badge { position:relative;line-height: 3em;border:solid #999 1px;
-  	   text-align: center;font-size: 2em;}
-    .badge[data-badge]:after {
-	   content:attr(data-badge);
-	   position:absolute;
-	   top:1px;
-	   left:1px;
-	   font-size:.7em;
-	   background:#9af;
-	   color:white;
-	   width:18px;height:18px;
-	   text-align:center;
-	   line-height:18px;
-	   box-shadow:0 0 1px #333;
-      }
-    </style>
+    <link rel="stylesheet" href="assets/style.css">
   </head>
   <body>
     <form method='post' action='result.php'>

--- a/php_server.log
+++ b/php_server.log
@@ -1,0 +1,13 @@
+[Sat Jun  6 14:46:26 2026] PHP 8.3.6 Development Server (http://localhost:3000) started
+[Sat Jun  6 14:47:04 2026] [::1]:59978 Accepted
+[Sat Jun  6 14:47:04 2026] [::1]:59978 [200]: GET /index.php
+[Sat Jun  6 14:47:04 2026] [::1]:59978 Closing
+[Sat Jun  6 14:47:04 2026] [::1]:59990 Accepted
+[Sat Jun  6 14:47:04 2026] [::1]:59990 [200]: GET /assets/style.css
+[Sat Jun  6 14:47:04 2026] [::1]:59990 Closing
+[Sat Jun  6 14:47:06 2026] [::1]:60002 Accepted
+[Sat Jun  6 14:47:06 2026] [::1]:60002 [200]: GET /result.php
+[Sat Jun  6 14:47:06 2026] [::1]:60002 Closing
+[Sat Jun  6 14:47:06 2026] [::1]:60006 Accepted
+[Sat Jun  6 14:47:06 2026] [::1]:60006 [200]: GET /assets/style.css
+[Sat Jun  6 14:47:06 2026] [::1]:60006 Closing

--- a/result.php
+++ b/result.php
@@ -10,35 +10,7 @@ UPDATED DATE : 2019-07-14
 <html>
   <head>
     <title>DISC Personality Test</title>
-    <style>
-    body,table {font-family: verdana,arial,sans-serif;font-size: 1em;}
-    input {background-color: #eee;line-height:1.5em;}
-    thead {background-color: #666;color: #fff;line-height: 2em; padding:0.2em;}
-    tfoot {background-color: #999;color: #fff;}
-    td {padding:0.2em;}
-    caption {font-size: 2em;}
-    input[type=radio]{border-radius: 0;width:2.2em;height:2.2em;}
-    .btn {background-color: #eee;line-height:2em;padding:0.1em 0.6em;
-    	  margin:0.2em;font-size:1.5em;font-weight:bold;
-    	  border-radius: 0.3em;}
-    .dark {background-color: #eee;}
-    .first {border-top: solid 0.2em #000; }
-    .badge { position:relative;line-height: 3em;border:solid #999 1px;
-    		 text-align: center;font-size: 2em;}
-	.badge[data-badge]:after {
-	   content:attr(data-badge);
-	   position:absolute;
-	   top:1px;
-	   left:1px;
-	   font-size:.7em;
-	   background:#9af;
-	   color:white;
-	   width:18px;height:18px;
-	   text-align:center;
-	   line-height:18px;
-	   box-shadow:0 0 1px #333;
-	}
-    </style>
+    <link rel="stylesheet" href="assets/style.css">
   </head>
   <body>
 <?php


### PR DESCRIPTION
🎯 **What:** Extracted duplicated inline `<style>` blocks from `index.php` and `result.php` into a single external stylesheet (`assets/style.css`).

💡 **Why:** Having CSS embedded in multiple PHP files leads to code duplication, making it difficult to maintain and ensure consistency across the application. Moving styles to an external stylesheet adheres to the DRY principle and improves separation of concerns.

✅ **Verification:** Verified the fix by rendering `index.php` and `result.php` in a Playwright script to ensure the UI visually matches the original, taking a screenshot and recording a video. Also ran syntax checks (`php -l`) and the custom test suite to ensure no regressions were introduced.

✨ **Result:** A cleaner, more maintainable codebase with styles centralized in one file, reducing duplication and improving readability.

---
*PR created automatically by Jules for task [7517559353608753318](https://jules.google.com/task/7517559353608753318) started by @cahyadsn*