### PR TITLE
🧹 [code health improvement] Remove unused show_mark debug variable

### DIFF
--- a/index.php
+++ b/index.php
@@ -40,7 +40,6 @@ if ($data === null || !is_array($data)) {
     }
 }
 
-$show_mark	= 0;	//<-- show 1 or hide 0 the marker
 $cols  		= 4;	//<-- number of columns
 $rows 		= count($data)/(4*$cols);
 ?>
@@ -124,16 +123,12 @@ $rows 		= count($data)/(4*$cols);
 		        		<input type='radio' 
 					       name='m[{$inr}]'
 						   value='{$most}'
-		        			   required />" 
-				 .($show_mark ? $most : '')
-		        	 ."</td>
+						   required /></td>
 				  <td{$isFirst}>
 		          		<input type='radio' 
 					       name='l[{$inr}]'
 					       value='{$least}'
-		          		       required />"
-				 .($show_mark ? $least : '')
-		          	 ."</td>";
+					       required /></td>";
           	}
           echo "</tr>";
         }


### PR DESCRIPTION
🎯 **What:** Removed the `$show_mark` variable and its associated ternary conditions from the table cell rendering logic in `index.php`.
💡 **Why:** `$show_mark` was statically defined as `0` and acted as dead debug code, making the template slightly harder to read and evaluate. Removing it improves codebase maintainability and reduces visual noise.
✅ **Verification:** Verified that `php -l index.php` reported no syntax errors and ran the full ad-hoc custom test suite (`for t in tests/test_*.php; do php "$t"; done`) which passed flawlessly.
✨ **Result:** Cleaned up code rendering logic with no functional changes.

---
*PR created automatically by Jules for task [2069455913539730927](https://jules.google.com/task/2069455913539730927) started by @cahyadsn*