### PR TITLE
🔒 Fix database connection error handling

### DIFF
--- a/db.php
+++ b/db.php
@@ -9,4 +9,11 @@ if ($dbpass === false) {
 $dbname = getenv('DB_NAME') ?: 'test';
 
 //-- database connection
-$db = new mysqli($dbhost, $dbuser, $dbpass, $dbname);
+try {
+    $db = @new mysqli($dbhost, $dbuser, $dbpass, $dbname);
+    if ($db->connect_error) {
+        throw new Exception('Database connection failed.');
+    }
+} catch (Throwable $e) {
+    throw new Exception('Database connection failed.');
+}


### PR DESCRIPTION
🎯 **What:** The vulnerability fixed
Missing error handling for the `mysqli` database connection in `db.php` could allow native PHP warnings or uncaught `mysqli_sql_exception` errors to expose sensitive information such as database credentials, host IPs, and internal paths.

⚠️ **Risk:** The potential impact if left unfixed
If a database connection failure occurs in production (e.g., database goes down or credentials expire), an attacker viewing the error output or stack traces might obtain the raw database username, password, or server information. This could facilitate lateral movement or direct database compromise.

🛡️ **Solution:** How the fix addresses the vulnerability
The database connection has been wrapped in a `try...catch` block. The native `mysqli` connection error warnings are suppressed using the `@` operator. Both `$db->connect_error` conditions and any thrown `Throwable` (such as `mysqli_sql_exception` in PHP 8.3+) are caught, resulting in a safe, generic `Exception('Database connection failed.')` that successfully masks all sensitive details.

---
*PR created automatically by Jules for task [12767617885761195427](https://jules.google.com/task/12767617885761195427) started by @cahyadsn*