### PR TITLE
🔒 Fix uncaught exception data leak in result.php

### DIFF
--- a/result.php
+++ b/result.php
@@ -53,8 +53,12 @@ if(isset($_POST['m']) && isset($_POST['l']) && is_array($_POST['m']) && is_array
 		$val_c = 14;
 		$stmt->execute();
 		$db_result=$stmt->get_result();
-		$data=(isset($db_result)&& !empty($db_result))?$db_result->fetch_object():throw new Exception('Data not found, check your database');
+		$data=(isset($db_result)&& !empty($db_result))?$db_result->fetch_object():null;
 	}
+
+	if (!$data) {
+		echo "    <div>\n      <h1>Error</h1>\n      <p>Data not found, check your database.</p>\n    </div>\n";
+	} else {
     ?>
     <div>
     <h1>RESULT</h1>
@@ -72,6 +76,7 @@ if(isset($_POST['m']) && isset($_POST['l']) && is_array($_POST['m']) && is_array
     <b>Description : </b><br /><?php echo htmlspecialchars($data->description, ENT_QUOTES, 'UTF-8');?><br />
     </div>
 <?php
+	}
 }
 ?>    
   </body>

--- a/tests/test_exception_leak.php
+++ b/tests/test_exception_leak.php
@@ -1,0 +1,51 @@
+<?php
+echo "Running Exception Leak test...\n";
+
+class MockResult {
+    public function fetch_object() {
+        return null; // Return null to trigger the empty condition
+    }
+}
+
+class MockStmt {
+    public function bind_param() {}
+    public function execute() {}
+    public function get_result() {
+        return new MockResult();
+    }
+}
+
+class MockMySQLi {
+    public function prepare($sql) {
+        return new MockStmt();
+    }
+}
+
+putenv('DB_HOST=127.0.0.1');
+
+try {
+    @include __DIR__ . '/../db.php';
+} catch (Throwable $e) {}
+
+global $db;
+$db = new MockMySQLi();
+
+$_POST['m'] = ['D'];
+$_POST['l'] = ['I'];
+
+ob_start();
+try {
+    include __DIR__ . '/../result.php';
+    $output = ob_get_clean();
+    if (strpos($output, 'Data not found, check your database') !== false) {
+        echo "PASS: Caught the error gracefully without uncaught exception.\n";
+        exit(0);
+    } else {
+        echo "FAIL: Expected error message not found in output.\n";
+        exit(1);
+    }
+} catch (Exception $e) {
+    ob_end_clean();
+    echo "FAIL: Uncaught exception thrown! " . $e->getMessage() . "\n";
+    exit(1);
+}


### PR DESCRIPTION
🎯 **What:** Modified `result.php` to prevent an uncaught `Exception` from being thrown when the database query returns no data or fails.
⚠️ **Risk:** An uncaught exception leads to an unhandled crash and prints stack traces or system file paths to the user, potentially leaking sensitive configuration details and exposing the application to further reconnaissance attacks.
🛡️ **Solution:** Replaced the ternary `throw new Exception` branch with `null` assignment. Added an `if (!$data)` conditional block to gracefully capture the missing data state and display a user-friendly error message, wrapping the regular HTML result view in an `else` block to prevent partial rendering and avoid halting execution with `exit;` which makes it compatible with our test suite. Added a test script (`tests/test_exception_leak.php`) to simulate the failing query scenario and ensure errors are gracefully caught.

---
*PR created automatically by Jules for task [6046769568314072477](https://jules.google.com/task/6046769568314072477) started by @cahyadsn*