### PR TITLE
🧪 Handle $db->query() failure gracefully in index.php

### DIFF
--- a/index.php
+++ b/index.php
@@ -22,15 +22,20 @@ if ($html_content === false) {
     $sql='SELECT * FROM personalities ORDER BY no ASC';
     $result=$db->query($sql);
     $data=array();
-    while($row=$result->fetch_object()) {
-        $row->term = htmlspecialchars($row->term, ENT_QUOTES, 'UTF-8');
-        $row->most = htmlspecialchars($row->most, ENT_QUOTES, 'UTF-8');
-        $row->least = htmlspecialchars($row->least, ENT_QUOTES, 'UTF-8');
-        $data[]=$row;
+    if ($result) {
+        while($row=$result->fetch_object()) {
+            $row->term = htmlspecialchars($row->term, ENT_QUOTES, 'UTF-8');
+            $row->most = htmlspecialchars($row->most, ENT_QUOTES, 'UTF-8');
+            $row->least = htmlspecialchars($row->least, ENT_QUOTES, 'UTF-8');
+            $data[]=$row;
+        }
     }
 
     $rows 		= count($data)/(4*$cols);
     ob_start();
+      if (!$result) {
+          echo "<tr><td colspan='16' style='text-align:center; color:red;'>Error loading data.</td></tr>";
+      }
       for($i=0;$i<$rows;++$i){
         echo "<tr".($i%2==0?" class='dark'":"").">";
         for($j=0;$j<$cols;++$j){
@@ -68,8 +73,10 @@ if ($html_content === false) {
         }
       }
     $html_content = ob_get_clean();
-    if (file_put_contents($html_cache_file, $html_content, LOCK_EX) === false) {
-        error_log("Failed to write to HTML cache file: $html_cache_file");
+    if ($result) {
+        if (file_put_contents($html_cache_file, $html_content, LOCK_EX) === false) {
+            error_log("Failed to write to HTML cache file: $html_cache_file");
+        }
     }
 }
 ?>

--- a/tests/test_index_query_failure.php
+++ b/tests/test_index_query_failure.php
@@ -1,0 +1,28 @@
+<?php
+
+class MockMySQLi {
+    public function query($sql) {
+        return false; // Simulate query failure
+    }
+}
+
+try {
+    @include __DIR__ . '/../db.php';
+} catch (Throwable $e) {}
+
+global $db;
+$db = new MockMySQLi();
+
+@unlink(__DIR__ . '/../html_cache.html');
+
+ob_start();
+include __DIR__ . '/../index.php';
+$output = ob_get_clean();
+
+if (strpos($output, "Error loading data.") !== false) {
+    echo "PASS: Gracefully handled query failure.\n";
+    exit(0);
+} else {
+    echo "FAIL: Did not gracefully handle query failure.\n";
+    exit(1);
+}


### PR DESCRIPTION
🎯 **What:** The previous code in `index.php` crashed with a fatal PHP error ("Call to a member function fetch_object() on false") if `$db->query($sql)` failed and returned false. This change explicitly checks the result and outputs a graceful error row instead.

📊 **Coverage:** A new test case `tests/test_index_query_failure.php` was added which mocks the `mysqli` object to simulate a failed query.

✨ **Result:** Test coverage improved by properly handling a failure scenario where the database connection is established but the subsequent query fails (e.g., due to a temporary outage or missing table). The application now prevents writing this error state to the HTML cache.

---
*PR created automatically by Jules for task [6392273227920995510](https://jules.google.com/task/6392273227920995510) started by @cahyadsn*