### PR TITLE
🧹 Extract magic numbers for fallback default into constants in result.php

### DIFF
--- a/result.php
+++ b/result.php
@@ -5,6 +5,12 @@ AUTHOR       : CAHYA DSN
 CREATED DATE : 2015-01-11
 UPDATED DATE : 2019-07-14
 *************************************/
+
+const DEFAULT_VAL_D = 15;
+const DEFAULT_VAL_I = 14;
+const DEFAULT_VAL_S = 15;
+const DEFAULT_VAL_C = 14;
+
 ?>
 <!doctype html>
 <html>
@@ -47,10 +53,10 @@ if(isset($_POST['m']) && isset($_POST['l']) && is_array($_POST['m']) && is_array
 	$data=(isset($db_result)&& !empty($db_result))?$db_result->fetch_object():'';
 	//-- if empty result found, get default result
 	if(!isset($data->name)){
-		$val_d = 15;
-		$val_i = 14;
-		$val_s = 15;
-		$val_c = 14;
+		$val_d = DEFAULT_VAL_D;
+		$val_i = DEFAULT_VAL_I;
+		$val_s = DEFAULT_VAL_S;
+		$val_c = DEFAULT_VAL_C;
 		$stmt->execute();
 		$db_result=$stmt->get_result();
 		$data=(isset($db_result)&& !empty($db_result))?$db_result->fetch_object():null;


### PR DESCRIPTION
🎯 **What:** The magic numbers (15, 14, 15, 14) used as default fallback values in `result.php` when an empty result is found have been extracted into named constants (`DEFAULT_VAL_D`, `DEFAULT_VAL_I`, `DEFAULT_VAL_S`, `DEFAULT_VAL_C`) at the top of the file.

💡 **Why:** This improves the code's maintainability and readability by giving meaningful names to these previously obscure magic numbers and centralizing their definition, making future updates easier.

✅ **Verification:** Verified that `php -l result.php` returned no syntax errors. Successfully ran the full test suite (`rm -f html_cache.html personalities_cache.json && for t in tests/test_*.php; do php "$t"; done && rm -f html_cache.html personalities_cache.json`), confirming that the default fallback logic still behaves identically (verified via the `tests/test_result_fallback.php` test).

✨ **Result:** A cleaner, more readable `result.php` with self-documenting fallback constants instead of hardcoded magic numbers, without affecting existing functionality.

---
*PR created automatically by Jules for task [9008975477354036775](https://jules.google.com/task/9008975477354036775) started by @cahyadsn*