### PR TITLE
🧹 Fix redundant variable checks in result.php

### DIFF
--- a/result.php
+++ b/result.php
@@ -50,7 +50,7 @@ if(isset($_POST['m']) && isset($_POST['l']) && is_array($_POST['m']) && is_array
 	$stmt->bind_param("iiii", $val_d, $val_i, $val_s, $val_c);
 	$stmt->execute();
 	$db_result=$stmt->get_result();
-	$data=(isset($db_result)&& !empty($db_result))?$db_result->fetch_object():'';
+	$data = $db_result ? $db_result->fetch_object() : '';
 	//-- if empty result found, get default result
 	if(!isset($data->name)){
 		$val_d = DEFAULT_VAL_D;
@@ -59,7 +59,7 @@ if(isset($_POST['m']) && isset($_POST['l']) && is_array($_POST['m']) && is_array
 		$val_c = DEFAULT_VAL_C;
 		$stmt->execute();
 		$db_result=$stmt->get_result();
-		$data=(isset($db_result)&& !empty($db_result))?$db_result->fetch_object():null;
+		$data = $db_result ? $db_result->fetch_object() : null;
 	}
 
 	if (!$data) {


### PR DESCRIPTION
🎯 **What:** Simplified `$db_result` checks in `result.php` by removing unnecessary `isset` and `!empty` calls.
💡 **Why:** `get_result()` returns an object or false. Checking if `$db_result` is truthy is sufficient and cleaner, improving readability.
✅ **Verification:** Ran syntax check (`php -l result.php`) and full test suite successfully.
✨ **Result:** Cleaner and more maintainable code without changing behavior.

---
*PR created automatically by Jules for task [1099844501857325395](https://jules.google.com/task/1099844501857325395) started by @cahyadsn*