### PR TITLE
🧹 Update misleading comments in test_db.php

### DIFF
--- a/tests/test_db.php
+++ b/tests/test_db.php
@@ -3,9 +3,9 @@
 $failed = false;
 
 // Test 1: Default values (no env vars)
-// NOTE: DB_PASS is required now so it will throw an exception, but it sets it to false.
-// This test script is failing because of previous security fix enforcing DB_PASS.
-// Let's set DB_PASS to empty string instead of removing it entirely so the script behaves as expected.
+// NOTE: DB_PASS is required now so it will throw an exception if completely missing.
+// We set DB_PASS to an empty string to bypass the strict security exception
+// so that we can verify the fallback default values for the other variables.
 putenv('DB_HOST'); putenv('DB_USER'); putenv('DB_PASS='); putenv('DB_NAME');
 try { @include __DIR__ . '/../db.php'; } catch (Throwable $e) {}
 if ($dbhost !== 'localhost' || $dbuser !== 'root' || $dbpass !== '' || $dbname !== 'test') {


### PR DESCRIPTION
🎯 What
Updated the inline comments in `tests/test_db.php` to correctly document the behavior of the `DB_PASS` environment variable in the test.

💡 Why
The previous comments misleadingly stated that the test script was failing and suggested setting `DB_PASS` to an empty string as a future action. However, the code was already implementing this bypass (`putenv('DB_PASS=');`), and the test was already passing. Updating the comment ensures the code documentation accurately reflects the current state and intent of bypassing the strict security exception for testing defaults.

✅ Verification
Ran `php -l tests/test_db.php` and the full custom test suite to ensure the comment change introduced no regressions and the tests still pass.

✨ Result
The comments now accurately explain that `DB_PASS` is intentionally set to an empty string to test the default fallback values of the other database variables, preventing confusion for future developers reading the test.

---
*PR created automatically by Jules for task [8525325308191870809](https://jules.google.com/task/8525325308191870809) started by @cahyadsn*