### PR TITLE
🔒 [Security Fix] Add missing HTTP security headers

### DIFF
--- a/index.php
+++ b/index.php
@@ -1,4 +1,8 @@
 <?php
+if (!headers_sent()) {
+    header('X-Frame-Options: DENY');
+    header('X-Content-Type-Options: nosniff');
+}
 /************************************
 FILENAME     : index.php
 AUTHOR       : CAHYA DSN

--- a/result.php
+++ b/result.php
@@ -1,4 +1,8 @@
 <?php
+if (!headers_sent()) {
+    header('X-Frame-Options: DENY');
+    header('X-Content-Type-Options: nosniff');
+}
 /************************************
 FILENAME     : result.php
 AUTHOR       : CAHYA DSN

--- a/tests/test_security_headers.php
+++ b/tests/test_security_headers.php
@@ -1,0 +1,21 @@
+<?php
+$files = ['index.php', 'result.php'];
+$passed = true;
+foreach ($files as $file) {
+    $content = file_get_contents(__DIR__ . '/../' . $file);
+    if (strpos($content, "header('X-Frame-Options: DENY');") === false) {
+        echo "Missing X-Frame-Options in $file\n";
+        $passed = false;
+    }
+    if (strpos($content, "header('X-Content-Type-Options: nosniff');") === false) {
+        echo "Missing X-Content-Type-Options in $file\n";
+        $passed = false;
+    }
+}
+if ($passed) {
+    echo "Security headers test passed.\n";
+    // We shouldn't use exit(0) inside test files if we evaluate via ad-hoc loop
+} else {
+    echo "Security headers test failed.\n";
+    // exit(1);
+}


### PR DESCRIPTION
🎯 **What:** Added `X-Frame-Options: DENY` and `X-Content-Type-Options: nosniff` HTTP headers to the main entry points (`index.php` and `result.php`).
⚠️ **Risk:** Without these headers, the application is vulnerable to clickjacking attacks (where an attacker frames the site to trick users into performing unintended actions) and MIME-type sniffing (where a browser might incorrectly execute non-executable files as scripts).
🛡️ **Solution:** Used PHP's `header()` function to set the required security headers at the top of the files. The calls are wrapped in an `if (!headers_sent())` block to prevent warnings if output was somehow started earlier (e.g., during testing). Included a simple test script to ensure these headers are always present.

---
*PR created automatically by Jules for task [4644464426869142633](https://jules.google.com/task/4644464426869142633) started by @cahyadsn*