### PR TITLE
🧹 Fix type mismatch for object fallback in result.php

### DIFF
--- a/result.php
+++ b/result.php
@@ -63,7 +63,7 @@ if(isset($_POST['m']) && isset($_POST['l']) && is_array($_POST['m']) && is_array
 	$stmt->bind_param("iiii", $val_d, $val_i, $val_s, $val_c);
 	$stmt->execute();
 	$db_result=$stmt->get_result();
-	$data = $db_result ? $db_result->fetch_object() : '';
+	$data = $db_result ? $db_result->fetch_object() : null;
 	//-- if empty result found, get default result
 	if(!isset($data->name)){
 		$val_d = DEFAULT_VAL_D;


### PR DESCRIPTION
🎯 **What:** Replaced the empty string (`''`) fallback with `null` when retrieving a database object via `$db_result->fetch_object()` in `result.php`.

💡 **Why:** Using an empty string as a fallback for an object fetch can lead to type mismatches and property access warnings (e.g., trying to access property of string) when an empty result is returned. Using `null` is type-safe and more idiomatic, as `isset(null->name)` gracefully evaluates to `false` in PHP 8+ without generating warnings.

✅ **Verification:** 
- Syntactically validated the modified file (`php -l result.php`).
- Ran the entire ad-hoc test suite to confirm no regressions. All tests, including the `result_fallback` specific test, passed successfully.

✨ **Result:** Improved type safety and code health, preventing potential runtime warnings on empty result sets while maintaining original functionality.

---
*PR created automatically by Jules for task [4056748520077788747](https://jules.google.com/task/4056748520077788747) started by @cahyadsn*