### PR TITLE
🧹 Remove error suppression operator in db.php

### DIFF
--- a/db.php
+++ b/db.php
@@ -13,7 +13,7 @@ $dbname = getenv('DB_NAME') ?: 'test';
 try {
     // Bolt optimization: Prefix the hostname with 'p:' to enable persistent connection pooling
     // in mysqli, reducing TCP handshake and authentication overhead per request.
-    $db = @new mysqli((strpos($dbhost, 'p:') === 0 ? $dbhost : 'p:' . $dbhost), $dbuser, $dbpass, $dbname);
+    $db = new mysqli((strpos($dbhost, 'p:') === 0 ? $dbhost : 'p:' . $dbhost), $dbuser, $dbpass, $dbname);
     if ($db->connect_error) {
         throw new Exception('Database connection failed.');
     }


### PR DESCRIPTION
🎯 **What:** Removed the `@` error suppression operator from the `new mysqli()` connection instantiation in `db.php`.

💡 **Why:** The `@` operator silently swallows PHP warnings or errors (such as connection refused). Removing it improves error visibility. Since the instantiation is already safely wrapped in a `try...catch (Throwable $e)` block, any potential exceptions or errors are properly caught and handled without leaking sensitive information, relying on standard exception handling rather than error suppression.

✅ **Verification:** 
- Syntactically verified `db.php` (`php -l db.php`).
- Ran the full test suite (`rm -f html_cache.html personalities_cache.json && for t in tests/test_*.php; do php "$t"; done`) which all passed, confirming that no existing logic or connection failure handling was broken.

✨ **Result:** Improved codebase maintainability by enhancing error visibility and removing an anti-pattern (the `@` operator), allowing exceptions to flow properly.

---
*PR created automatically by Jules for task [18350585589251337525](https://jules.google.com/task/18350585589251337525) started by @cahyadsn*