### PR TITLE
⚡ Bolt: Eliminate array allocations in rendering loop

### DIFF
--- a/index.php
+++ b/index.php
@@ -42,26 +42,20 @@ if ($html_content === false) {
       }
       $html = [];
       for($i=0;$i<$rows;++$i){
-        $inr_cache = [];
-        $idx_base = [];
-        for($n=0;$n<4;++$n){
-            $inr_cache[$n] = $i+$n*$rows;
-            $idx_base[$n] = $cols*$inr_cache[$n];
-        }
-
+        // Bolt optimization: Eliminated inner-loop array allocations ($inr_cache, $idx_base) by calculating invariants directly, reducing memory overhead and loop initialization time.
         $tr = $i%2==0 ? "<tr class='dark'>" : "<tr>";
         $html[] = $tr;
         for($j=0;$j<$cols;++$j){
             $isFirst = $j==0 ? " class='first'" : "";
         	for($n=0;$n<4;++$n){
-                $inr = $inr_cache[$n];
+                $inr = $i + $n * $rows;
 
          		if($j>0 && $n==0){
 				$html[] = $tr;
          		}elseif($j==0){
 				    $html[] = "<th rowspan='$cols'{$isFirst}>".($inr+1)."</th>";
          		}
-		        $item = $data[$idx_base[$n]+$j];
+		        $item = $data[$cols * $inr + $j];
 
 		        $html[] = "<td{$isFirst}>
 					{$item->term}


### PR DESCRIPTION
💡 What:
Eliminated the `$inr_cache` and `$idx_base` array allocations inside the outer rendering loop in `index.php`, replacing them with direct scalar math calculations in the inner loop.

🎯 Why:
In PHP, the overhead of creating, populating, and looking up values in small arrays within tight inner loops can outweigh the perceived benefit of "caching" simple math. By computing `$inr` and the `$data` index directly with multiplication and addition, we reduce memory allocation overhead, decrease garbage collection pressure, and bypass loop initialization time entirely.

📊 Impact:
Micro-optimization. This reduces memory pressure and slightly improves rendering time when the HTML cache is cold or bypassed. Wait times are reduced by removing repeated iterations that initialize short-lived array structures.

🔬 Measurement:
1. Validated changes mathematically against the original index logic: `$inr_cache[$n]` was `$i + $n * $rows`, and `$idx_base[$n] + $j` was `$cols * $inr + $j`. The replacement performs these same operations directly.
2. Verified there are no syntax errors via `php -l index.php`.
3. Executed full test suite (`tests/test_*.php`) successfully without regressions.

---
*PR created automatically by Jules for task [15457328031998646391](https://jules.google.com/task/15457328031998646391) started by @cahyadsn*