### PR TITLE
🧹 Fix discarded exception context in db.php

### DIFF
--- a/db.php
+++ b/db.php
@@ -18,5 +18,5 @@ try {
         throw new Exception('Database connection failed.');
     }
 } catch (Throwable $e) {
-    throw new Exception('Database connection failed.');
+    throw new Exception('Database connection failed.', 0, $e);
 }


### PR DESCRIPTION
🎯 **What:** Modified the `catch (Throwable $e)` block in `db.php` to pass the caught exception `$e` as the third argument to the `Exception` constructor (`throw new Exception('Database connection failed.', 0, $e);`).

💡 **Why:** When re-throwing exceptions, failing to pass the originally caught exception discards its context and stack trace, making debugging extremely difficult. Preserving the context ensures the original source of the exception is maintained in the error log stack trace.

✅ **Verification:** 
- Syntactically verified using `php -l db.php`.
- Ran the entire ad-hoc test suite (`tests/test_*.php`) and confirmed that everything still passes without issue.

✨ **Result:** Enhanced the error observability of database connection failures without altering any application behavior.

---
*PR created automatically by Jules for task [14156006472870105652](https://jules.google.com/task/14156006472870105652) started by @cahyadsn*