### PR TITLE
🧹 [remove unnecessary '#' aspect processing]

### DIFF
--- a/result.php
+++ b/result.php
@@ -32,7 +32,7 @@ if(isset($_POST['m']) && isset($_POST['l']) && is_array($_POST['m']) && is_array
   $least = [];
   foreach ($_POST['l'] as $v) if (is_scalar($v)) $least[$v] = ($least[$v] ?? 0) + 1;
   $result=array();
-  $aspect=array('D','I','S','C','#');
+  $aspect=array('D','I','S','C');
   // Bolt optimization: Extract array values to variables and use null coalescing operator to avoid duplicate hash lookups and optimize array assignment
   foreach($aspect as $a){
     $m = $most[$a] ?? 0;
@@ -40,7 +40,7 @@ if(isset($_POST['m']) && isset($_POST['l']) && is_array($_POST['m']) && is_array
     $result[$a] = [
         'most' => $m,
         'least' => $l,
-        'change' => ($a !== '#' ? $m - $l : 0)
+        'change' => $m - $l
     ];
   }
 

--- a/tests/DiscTest.php
+++ b/tests/DiscTest.php
@@ -13,10 +13,10 @@ class DiscTest extends TestCase
         $leastCounts = array_count_values(array_filter($least, 'is_scalar'));
         
         $result = [];
-        foreach (['D', 'I', 'S', 'C', '#'] as $a) {
+        foreach (['D', 'I', 'S', 'C'] as $a) {
             $result[$a]['most'] = $mostCounts[$a] ?? 0;
             $result[$a]['least'] = $leastCounts[$a] ?? 0;
-            $result[$a]['change'] = ($a !== '#') ? $result[$a]['most'] - $result[$a]['least'] : 0;
+            $result[$a]['change'] = $result[$a]['most'] - $result[$a]['least'];
         }
         return $result;
     }
@@ -67,18 +67,6 @@ class DiscTest extends TestCase
         
         $this->assertStringNotContainsString('<script>', $escaped);
         $this->assertStringContainsString('&lt;script&gt;', $escaped);
-    }
-
-    public function testHashDimensionChangeAlwaysZero(): void
-    {
-        $most = ['#', '#', '#'];
-        $least = ['#'];
-        
-        $result = $this->calculateScores($most, $least);
-        
-        $this->assertEquals(3, $result['#']['most']);
-        $this->assertEquals(1, $result['#']['least']);
-        $this->assertEquals(0, $result['#']['change']); // Always 0 for '#'
     }
 
     public function testNegativeChangeScore(): void


### PR DESCRIPTION
🎯 **What:** Removed the explicit bypass and empty processing logic for the `'#'` aspect in `result.php`. Simplified the value array processing to just `'D', 'I', 'S', 'C'`. The test suite `DiscTest.php` was correspondingly updated to remove assertions testing this dead code.
💡 **Why:** The original code iterated over a five-element array but explicitly checked and ignored the fifth element (`'#'`). Because the result of this element was never mapped to the database lookup or outputted, removing it entirely simplifies the `foreach` iteration and avoids a redundant conditional check on every element.
✅ **Verification:** Verified via `cat` output of the refactored files. Syntax tests passed. PHPUnit test suite was run for `DiscTest.php` proving the calculation still works correctly for standard input, and the full ad-hoc custom test suite was executed without any new failures or warnings.
✨ **Result:** Improved maintainability by removing unreachable and pointless code.

---
*PR created automatically by Jules for task [15081679529696872064](https://jules.google.com/task/15081679529696872064) started by @cahyadsn*