### PR TITLE
🧹 Guard against prepare() failure in result.php

### DIFF
--- a/result.php
+++ b/result.php
@@ -56,23 +56,26 @@ if(isset($_POST['m']) && isset($_POST['l']) && is_array($_POST['m']) && is_array
 		  AND a.s = (SELECT segment FROM results WHERE graph=3 AND dimension='S' AND value=? LIMIT 1)
 		  AND a.c = (SELECT segment FROM results WHERE graph=3 AND dimension='C' AND value=? LIMIT 1)";
 	$stmt = $db->prepare($sql);
-	$val_d = $result['D']['change'];
-	$val_i = $result['I']['change'];
-	$val_s = $result['S']['change'];
-	$val_c = $result['C']['change'];
-	$stmt->bind_param("iiii", $val_d, $val_i, $val_s, $val_c);
-	$stmt->execute();
-	$db_result=$stmt->get_result();
-	$data = $db_result ? $db_result->fetch_object() : null;
-	//-- if empty result found, get default result
-	if(!isset($data->name)){
-		$val_d = DEFAULT_VAL_D;
-		$val_i = DEFAULT_VAL_I;
-		$val_s = DEFAULT_VAL_S;
-		$val_c = DEFAULT_VAL_C;
+	$data = null;
+	if ($stmt) {
+		$val_d = $result['D']['change'];
+		$val_i = $result['I']['change'];
+		$val_s = $result['S']['change'];
+		$val_c = $result['C']['change'];
+		$stmt->bind_param("iiii", $val_d, $val_i, $val_s, $val_c);
 		$stmt->execute();
 		$db_result=$stmt->get_result();
 		$data = $db_result ? $db_result->fetch_object() : null;
+		//-- if empty result found, get default result
+		if(!isset($data->name)){
+			$val_d = DEFAULT_VAL_D;
+			$val_i = DEFAULT_VAL_I;
+			$val_s = DEFAULT_VAL_S;
+			$val_c = DEFAULT_VAL_C;
+			$stmt->execute();
+			$db_result=$stmt->get_result();
+			$data = $db_result ? $db_result->fetch_object() : null;
+		}
 	}
 
 	if (!$data) {

--- a/tests/test_prepare_false.php
+++ b/tests/test_prepare_false.php
@@ -1,0 +1,34 @@
+<?php
+try {
+    putenv('DB_PASS='); // Ensure no Exception from db.php missing pass
+    require_once __DIR__ . '/../db.php';
+} catch (Throwable $e) {
+    // Suppress connection errors
+}
+
+$_POST['m'] = ['D'];
+$_POST['l'] = ['I'];
+
+class MockDbPrepareFalse {
+    public function prepare($sql) {
+        return false;
+    }
+}
+
+global $db;
+$db = new MockDbPrepareFalse();
+
+ob_start();
+try {
+    include __DIR__ . '/../result.php';
+} catch (Throwable $e) {
+    echo "CAUGHT: " . $e->getMessage() . "\n";
+}
+$output = ob_get_clean();
+
+if (strpos($output, 'Data not found, check your database.') !== false) {
+    echo "PASS: Handled prepare failure correctly.\n";
+} else {
+    echo "FAIL: Unexpected output:\n$output\n";
+    exit(1);
+}


### PR DESCRIPTION
🎯 **What:** Wrapped the execution logic in `result.php` within an `if ($stmt)` block.
💡 **Why:** To safely handle cases where `$db->prepare($sql)` returns `false` (e.g. database configuration errors or syntax issues), avoiding a fatal "Call to a member function bind_param() on false" error. This allows the application to gracefully fall back to the existing error message "Data not found, check your database."
✅ **Verification:** Verified by creating a new test file `tests/test_prepare_false.php` which mocks a `prepare()` failure and confirms the correct output is generated. Executed the full existing ad-hoc test suite to ensure no regressions.
✨ **Result:** Enhanced the resilience and maintainability of the codebase by explicitly handling edge cases and avoiding fatal application crashes.

---
*PR created automatically by Jules for task [16499498905174698409](https://jules.google.com/task/16499498905174698409) started by @cahyadsn*