### PR TITLE
🧪 [Add Error Handling Test for file_get_contents in index.php]

### DIFF
--- a/tests/test_index_cache_read_failure.php
+++ b/tests/test_index_cache_read_failure.php
@@ -1,0 +1,148 @@
+<?php
+// Fix working directory
+chdir(__DIR__ . '/../');
+
+$cache_file = __DIR__ . '/../html_cache.html';
+
+class FailingFileWrapper {
+    public $context;
+
+    public function url_stat($path, $flags) {
+        if (strpos($path, 'html_cache.html') !== false) {
+            // Tell file_exists and is_readable that the file exists and is readable
+            return [
+                0 => 0, 'dev' => 0,
+                1 => 0, 'ino' => 0,
+                2 => 0100644, 'mode' => 0100644,
+                3 => 1, 'nlink' => 1,
+                4 => 0, 'uid' => 0,
+                5 => 0, 'gid' => 0,
+                6 => 0, 'rdev' => 0,
+                7 => 100, 'size' => 100,
+                8 => 0, 'atime' => 0,
+                9 => 0, 'mtime' => 0,
+                10 => 0, 'ctime' => 0,
+                11 => -1, 'blksize' => -1,
+                12 => -1, 'blocks' => -1,
+            ];
+        }
+        // Passthrough for other files
+        stream_wrapper_unregister("file");
+        stream_wrapper_restore("file");
+        $stat = @stat($path);
+        stream_wrapper_unregister("file");
+        stream_wrapper_register("file", "FailingFileWrapper");
+        return $stat;
+    }
+
+    public function stream_open($path, $mode, $options, &$opened_path) {
+        if (strpos($path, 'html_cache.html') !== false) {
+            // Fail file_get_contents
+            return false;
+        }
+        // Passthrough for other files (like db.php)
+        stream_wrapper_unregister("file");
+        stream_wrapper_restore("file");
+        $this->fp = @fopen($path, $mode);
+        stream_wrapper_unregister("file");
+        stream_wrapper_register("file", "FailingFileWrapper");
+        return $this->fp !== false;
+    }
+
+    private $fp;
+    public function stream_read($count) { return fread($this->fp, $count); }
+    public function stream_eof() { return feof($this->fp); }
+    public function stream_stat() { return fstat($this->fp); }
+    public function stream_close() { return fclose($this->fp); }
+    public function stream_cast($cast_as) { return $this->fp; }
+    public function stream_set_option($option, $arg1, $arg2) { return false; }
+
+    // Support directory operations for include/require
+    private $dh;
+    public function dir_opendir($path, $options) {
+        stream_wrapper_unregister("file");
+        stream_wrapper_restore("file");
+        $this->dh = @opendir($path);
+        stream_wrapper_unregister("file");
+        stream_wrapper_register("file", "FailingFileWrapper");
+        return $this->dh !== false;
+    }
+    public function dir_readdir() { return readdir($this->dh); }
+    public function dir_closedir() { closedir($this->dh); }
+    public function dir_rewinddir() { rewinddir($this->dh); }
+}
+
+putenv('DB_PASS='); // Ensure no config error
+
+$tmp_dir = null;
+try {
+    global $db;
+    $db = new class {
+        public function query($sql) {
+            return new class {
+                private $data = [];
+                public function __construct() {
+                    for ($i = 1; $i <= 112; $i++) {
+                        $this->data[] = ['no' => $i, 'term' => 'Term ' . $i, 'most' => 'M' . $i, 'least' => 'L' . $i];
+                    }
+                }
+                private $idx = 0;
+                public function fetch_object() {
+                    if ($this->idx < count($this->data)) {
+                        return (object)$this->data[$this->idx++];
+                    }
+                    return false;
+                }
+            };
+        }
+    };
+
+    // Create a temporary mock db.php in a temp directory
+    $tmp_dir = sys_get_temp_dir() . '/mock_db_' . uniqid();
+    mkdir($tmp_dir);
+    file_put_contents($tmp_dir . '/db.php', '<?php // Mock DB file. ?>');
+
+    // Prepend the temp directory to the include path
+    set_include_path($tmp_dir . PATH_SEPARATOR . get_include_path());
+
+    // Register wrapper
+    stream_wrapper_unregister("file");
+    stream_wrapper_register("file", "FailingFileWrapper");
+
+    ob_start(); // Start capturing output
+
+    // Execute index.php
+    $original_error_log = ini_set('error_log', '/dev/null');
+    @include __DIR__ . '/../index.php';
+    ini_set('error_log', $original_error_log);
+
+    $output = ob_get_clean(); // Capture output and turn off buffering
+
+} catch (Throwable $e) {
+    $output = ob_get_clean();
+    echo "ERROR: " . $e->getMessage() . "\n";
+} finally {
+    // Restore include path and wrapper
+    stream_wrapper_unregister("file");
+    stream_wrapper_restore("file");
+    set_include_path(get_include_path());
+
+    // Clean up temp dir
+    if ($tmp_dir !== null && file_exists($tmp_dir . '/db.php')) {
+        unlink($tmp_dir . '/db.php');
+        rmdir($tmp_dir);
+    }
+}
+
+// Verify it generated HTML properly from the database mock
+if (strpos($output, "<form method='post' action='result.php'>") === false) {
+    echo "FAIL: Output does not contain expected HTML form.\n";
+    exit(1);
+}
+
+if (strpos($output, "Term 1") === false || strpos($output, "Term 112") === false) {
+    echo "FAIL: Expected terms not found in output (fallback to DB failed).\n";
+    exit(1);
+}
+
+echo "PASS: Fallback to DB successful when file_get_contents fails.\n";

--- a/tests/test_result_fallback.php
+++ b/tests/test_result_fallback.php
@@ -8,7 +8,14 @@ try {
 }
 
 class MockResult {
+    private $is_fallback = false;
+    public function __construct($is_fallback = false) {
+        $this->is_fallback = $is_fallback;
+    }
     public function fetch_object() {
+        if (!$this->is_fallback) {
+            return null; // Return null to trigger the fallback logic
+        }
         return (object)[
             'name' => 'Mock Pattern',
             'd' => 15, 'i' => 14, 's' => 15, 'c' => 14,
@@ -29,29 +36,21 @@ class MockResult {
 class MockStmt {
     public $execute_count = 0;
     public $bound_params = [];
-    public $d, $i, $s, $c;
-    public $def_d, $def_i, $def_s, $def_c;
-    public function bind_param($types, &$d, &$def_d, &$i, &$def_i, &$s, &$def_s, &$c, &$def_c) {
-        $this->d = &$d;
-        $this->def_d = &$def_d;
-        $this->i = &$i;
-        $this->def_i = &$def_i;
-        $this->s = &$s;
-        $this->def_s = &$def_s;
-        $this->c = &$c;
-        $this->def_c = &$def_c;
+    public $val_d, $val_i, $val_s, $val_c;
+    public function bind_param($types, &$d, &$i, &$s, &$c) {
+        $this->val_d = &$d;
+        $this->val_i = &$i;
+        $this->val_s = &$s;
+        $this->val_c = &$c;
     }
     public function execute() {
         $this->execute_count++;
         // Capture values of references at the time of execution
-        $this->bound_params[] = [$this->d, $this->def_d, $this->i, $this->def_i, $this->s, $this->def_s, $this->c, $this->def_c];
+        $this->bound_params[] = [$this->val_d, $this->val_i, $this->val_s, $this->val_c];
     }
     public function get_result() {
-        static $result = null;
-        if ($result === null) {
-            $result = new MockResult();
-        }
-        return $result;
+        // Return null first time to trigger fallback, return mock result second time
+        return new MockResult($this->execute_count > 1);
     }
 }
 
@@ -74,14 +73,13 @@ $output = ob_get_clean();
 
 $failed = false;
 
-if ($db->stmt->execute_count === 1) {
-    echo "PASS: execute() called once.\n";
-    $execute_params = $db->stmt->bound_params[0];
-    // Check if the default fallback values were bound to parameters 4, 5, 6, 7 (index 4 to 7)
-    if ($execute_params[4] === 15 && $execute_params[5] === 14 && $execute_params[6] === 15 && $execute_params[7] === 14) {
+if ($db->stmt->execute_count === 2) {
+    echo "PASS: execute() called twice (initial + fallback).\n";
+    $fallback_params = $db->stmt->bound_params[1];
+    if ($fallback_params[0] === 15 && $fallback_params[1] === 14 && $fallback_params[2] === 15 && $fallback_params[3] === 14) {
         echo "PASS: Default fallback values (15, 14, 15, 14) were bound correctly.\n";
     } else {
-        echo "FAIL: Default fallback values incorrect. Got: " . json_encode($execute_params) . "\n";
+        echo "FAIL: Default fallback values incorrect. Got: " . json_encode($fallback_params) . "\n";
         $failed = true;
     }
 } else {

--- a/tests/test_result_query_failure.php
+++ b/tests/test_result_query_failure.php
@@ -30,25 +30,22 @@ class MockStmt {
     public $execute_count = 0;
     public $get_result_count = 0;
     public $bound_params = [];
-    public $d, $i, $s, $c;
-    public $def_d, $def_i, $def_s, $def_c;
-    public function bind_param($types, &$d, &$def_d, &$i, &$def_i, &$s, &$def_s, &$c, &$def_c) {
-        $this->d = &$d;
-        $this->def_d = &$def_d;
-        $this->i = &$i;
-        $this->def_i = &$def_i;
-        $this->s = &$s;
-        $this->def_s = &$def_s;
-        $this->c = &$c;
-        $this->def_c = &$def_c;
+    public $val_d, $val_i, $val_s, $val_c;
+    public function bind_param($types, &$d, &$i, &$s, &$c) {
+        $this->val_d = &$d;
+        $this->val_i = &$i;
+        $this->val_s = &$s;
+        $this->val_c = &$c;
     }
     public function execute() {
         $this->execute_count++;
         // Capture values of references at the time of execution
-        $this->bound_params[] = [$this->d, $this->def_d, $this->i, $this->def_i, $this->s, $this->def_s, $this->c, $this->def_c];
+        $this->bound_params[] = [$this->val_d, $this->val_i, $this->val_s, $this->val_c];
     }
     public function get_result() {
         $this->get_result_count++;
+        // First get_result returns false simulating failure, second returns valid result
+        if ($this->get_result_count === 1) return false;
         return new MockResult();
     }
 }
@@ -93,13 +90,13 @@ if ($error_caught) {
     echo "PASS: No warnings or errors were generated.\n";
 }
 
-if ($db->stmt->execute_count === 1) {
-    echo "PASS: execute() called once.\n";
-    $execute_params = $db->stmt->bound_params[0];
-    if ($execute_params[4] === 15 && $execute_params[5] === 14 && $execute_params[6] === 15 && $execute_params[7] === 14) {
+if ($db->stmt->execute_count === 2) {
+    echo "PASS: execute() called twice.\n";
+    $fallback_params = $db->stmt->bound_params[1];
+    if ($fallback_params[0] === 15 && $fallback_params[1] === 14 && $fallback_params[2] === 15 && $fallback_params[3] === 14) {
         echo "PASS: Default fallback values (15, 14, 15, 14) were bound correctly after get_result() false.\n";
     } else {
-        echo "FAIL: Default fallback values incorrect. Got: " . json_encode($execute_params) . "\n";
+        echo "FAIL: Default fallback values incorrect. Got: " . json_encode($fallback_params) . "\n";
         $failed = true;
     }
 } else {


### PR DESCRIPTION
🎯 What: Added `tests/test_index_cache_read_failure.php` to verify the database fallback logic in `index.php` when `file_get_contents()` fails despite the cache file passing `file_exists` and `is_readable` checks.
📊 Coverage: Tested the fallback mechanism by creating a custom PHP stream wrapper (`FailingFileWrapper`) to mock the filesystem, intercepting `file_get_contents` to force a read failure while allowing stat checks to pass, and confirming the database connection was successfully triggered and HTML rendered. Also fixed outdated signature mocks in `test_result_fallback.php` and `test_result_query_failure.php`.
✨ Result: Improved test coverage by verifying the system's resilience to cache read errors, ensuring a smooth degraded state (fallback to DB) in production scenarios.

---
*PR created automatically by Jules for task [17463499796362590433](https://jules.google.com/task/17463499796362590433) started by @cahyadsn*