### PR TITLE
🧪 Add test for index.php empty result set

### DIFF
--- a/tests/test_index_empty_result.php
+++ b/tests/test_index_empty_result.php
@@ -1,0 +1,37 @@
+<?php
+putenv('DB_PASS='); // Avoid Exception
+
+class MockMySQLiResultEmpty {
+    public function fetch_object() {
+        return null;
+    }
+}
+
+class MockMySQLiEmpty {
+    public function query($sql) {
+        return new MockMySQLiResultEmpty();
+    }
+}
+
+try {
+    @include __DIR__ . '/../db.php';
+} catch (Throwable $e) {}
+
+global $db;
+$db = new MockMySQLiEmpty();
+
+@unlink(__DIR__ . '/../html_cache.html');
+
+ob_start();
+include __DIR__ . '/../index.php';
+$output = ob_get_clean();
+
+// If data is empty, the table body will be completely empty.
+// Let's verify that there is no error message, and no rows are rendered.
+if (strpos($output, "Error loading data.") === false && (strpos($output, "<tbody>\n      \n      </tbody>") !== false || preg_match("/<tbody>\s*<\/tbody>/", $output))) {
+    echo "PASS: Gracefully handled empty result set.\n";
+    exit(0);
+} else {
+    echo "FAIL: Did not gracefully handle empty result set.\n";
+    exit(1);
+}


### PR DESCRIPTION
🎯 **What:** The testing gap addressed was that there were no tests ensuring that `index.php` handled the `$db->query()` returning an empty result set safely.
📊 **Coverage:** This PR adds a procedural PHP test script (`tests/test_index_empty_result.php`) to test that if the personalities table is empty, `index.php` processes the result without throwing type or array offset errors, and gracefully displays no rows.
✨ **Result:** Test coverage for `index.php` error handling and edge cases has improved, ensuring future refactors won't inadvertently break this fallback behavior.

---
*PR created automatically by Jules for task [2580245915454253075](https://jules.google.com/task/2580245915454253075) started by @cahyadsn*