### PR TITLE
🔒 Security Fix: Add Content-Security-Policy (CSP) Header

### DIFF
--- a/index.php
+++ b/index.php
@@ -2,6 +2,7 @@
 if (!headers_sent()) {
     header('X-Frame-Options: DENY');
     header('X-Content-Type-Options: nosniff');
+    header("Content-Security-Policy: default-src 'self';");
 }
 /************************************
 FILENAME     : index.php

--- a/result.php
+++ b/result.php
@@ -2,6 +2,7 @@
 if (!headers_sent()) {
     header('X-Frame-Options: DENY');
     header('X-Content-Type-Options: nosniff');
+    header("Content-Security-Policy: default-src 'self';");
 }
 /************************************
 FILENAME     : result.php

--- a/tests/test_security_headers.php
+++ b/tests/test_security_headers.php
@@ -11,6 +11,10 @@ foreach ($files as $file) {
         echo "Missing X-Content-Type-Options in $file\n";
         $passed = false;
     }
+    if (strpos($content, "header(\"Content-Security-Policy: default-src 'self';\");") === false) {
+        echo "Missing Content-Security-Policy in $file\n";
+        $passed = false;
+    }
 }
 if ($passed) {
     echo "Security headers test passed.\n";


### PR DESCRIPTION
🎯 **What:** Added the `Content-Security-Policy: default-src 'self';` header to `index.php` and `result.php`. Updated the `test_security_headers.php` test script to verify its presence.
⚠️ **Risk:** Missing a Content-Security-Policy header makes the application more vulnerable to Cross-Site Scripting (XSS) attacks by allowing malicious actors to potentially load external resources or execute inline scripts.
🛡️ **Solution:** Implemented the baseline `default-src 'self';` policy which restricts resource loading to the same origin, mitigating unauthorized resource loading and strengthening the application's security posture.

---
*PR created automatically by Jules for task [10672303577803766597](https://jules.google.com/task/10672303577803766597) started by @cahyadsn*