### PR TITLE
🔒 Prevent exception stack trace leak in db config

### DIFF
--- a/conf/config.php
+++ b/conf/config.php
@@ -19,5 +19,5 @@ try {
         throw new Exception('Database connection failed.');
     }
 } catch (Throwable $e) {
-    throw new Exception('Database connection failed.', 0, $e);
+    throw new Exception('Database connection failed.');
 }


### PR DESCRIPTION
🎯 **What:** The application was passing the original Throwable (`$e`) into the new `Exception` thrown when the database connection failed in `conf/config.php`. This chained the exceptions and could leak the stack trace and configuration details (such as host, user, and internal file paths).

⚠️ **Risk:** If a database connection error was triggered and unhandled, the user or attacker could see the full exception trace containing sensitive connection details.

🛡️ **Solution:** Removed the `$e` parameter from the new `Exception` being thrown in `conf/config.php`. The generic "Database connection failed." message is still exposed, but the sensitive stack trace and underlying failure details are safely discarded.

---
*PR created automatically by Jules for task [18171788998743272032](https://jules.google.com/task/18171788998743272032) started by @cahyadsn*