### PR TITLE
🔒 Add Content-Security-Policy (CSP) header to mitigate XSS risks

### DIFF
--- a/index.php
+++ b/index.php
@@ -2,6 +2,7 @@
 if (!headers_sent()) {
     header('X-Frame-Options: DENY');
     header('X-Content-Type-Options: nosniff');
+    header("Content-Security-Policy: default-src 'self';");
 }
 /************************************
 FILENAME     : index.php

--- a/result.php
+++ b/result.php
@@ -2,6 +2,7 @@
 if (!headers_sent()) {
     header('X-Frame-Options: DENY');
     header('X-Content-Type-Options: nosniff');
+    header("Content-Security-Policy: default-src 'self';");
 }
 /************************************
 FILENAME     : result.php

--- a/tests/test_security_headers.php
+++ b/tests/test_security_headers.php
@@ -11,6 +11,10 @@ foreach ($files as $file) {
         echo "Missing X-Content-Type-Options in $file\n";
         $passed = false;
     }
+    if (strpos($content, "header(\"Content-Security-Policy: default-src 'self';\");") === false) {
+        echo "Missing Content-Security-Policy in $file\n";
+        $passed = false;
+    }
 }
 if ($passed) {
     echo "Security headers test passed.\n";


### PR DESCRIPTION
🎯 **What:** The application was missing a Content-Security-Policy (CSP) header in `result.php` and `index.php`. This patch adds `header("Content-Security-Policy: default-src 'self';");` alongside the existing security headers.
⚠️ **Risk:** Without a strict CSP, the application is more susceptible to Cross-Site Scripting (XSS) attacks. If an attacker could inject malicious scripts into the page, the browser would execute them, potentially leading to data theft or unauthorized actions.
🛡️ **Solution:** By adding `Content-Security-Policy: default-src 'self';`, we instruct the browser to only load and execute resources (scripts, styles, etc.) originating from the same domain as the application. This significantly reduces the attack surface by blocking inline scripts and resources from untrusted external domains. I also updated `tests/test_security_headers.php` to verify this new header.

---
*PR created automatically by Jules for task [12232073229839241004](https://jules.google.com/task/12232073229839241004) started by @cahyadsn*