### PR TITLE
🔒 Fix: Move HTML cache file outside of web root

### DIFF
--- a/index.php
+++ b/index.php
@@ -9,7 +9,7 @@ AUTHOR       : CAHYA DSN
 CREATED DATE : 2015-01-11
 UPDATED DATE : 2026-07-20 08:04:50
 *************************************/
-$html_cache_file = __DIR__ . '/html_cache.html';
+$html_cache_file = sys_get_temp_dir() . '/html_cache.html';
 $html_content = false;
 $cols  		= 4;	//<-- number of columns
 

--- a/tests/test_html_cache_write_failure.php
+++ b/tests/test_html_cache_write_failure.php
@@ -24,7 +24,7 @@ try { @include __DIR__ . '/../conf/config.php'; } catch (Throwable $e) {}
 global $db;
 $db = new MockMySQLi();
 
-$cache_file = __DIR__ . '/../html_cache.html';
+$cache_file = sys_get_temp_dir() . '/html_cache.html';
 system('rm -rf ' . escapeshellarg($cache_file));
 touch($cache_file);
 chmod($cache_file, 0000); // No permissions. This makes is_readable() false, and file_put_contents() fail.

--- a/tests/test_index_cache_read_failure.php
+++ b/tests/test_index_cache_read_failure.php
@@ -2,7 +2,7 @@
 // Fix working directory
 chdir(__DIR__ . '/../');
 
-$cache_file = __DIR__ . '/../html_cache.html';
+$cache_file = sys_get_temp_dir() . '/html_cache.html';
 
 class FailingFileWrapper {
     public $context;

--- a/tests/test_index_empty_result.php
+++ b/tests/test_index_empty_result.php
@@ -20,7 +20,7 @@ try {
 global $db;
 $db = new MockMySQLiEmpty();
 
-@unlink(__DIR__ . '/../html_cache.html');
+@unlink(sys_get_temp_dir() . '/html_cache.html');
 
 ob_start();
 include __DIR__ . '/../index.php';

--- a/tests/test_index_query_failure.php
+++ b/tests/test_index_query_failure.php
@@ -13,7 +13,7 @@ try {
 global $db;
 $db = new MockMySQLi();
 
-@unlink(__DIR__ . '/../html_cache.html');
+@unlink(sys_get_temp_dir() . '/html_cache.html');
 
 ob_start();
 include __DIR__ . '/../index.php';

--- a/tests/test_lazy_db.php
+++ b/tests/test_lazy_db.php
@@ -1,6 +1,6 @@
 <?php
 // We test if the database connection is avoided when cache is hit.
-$cache_file = __DIR__ . '/../html_cache.html';
+$cache_file = sys_get_temp_dir() . '/html_cache.html';
 
 // Create a dummy valid html cache (enough to suppress warnings)
 $dummy_data = [];

--- a/tests/test_unreadable_cache.php
+++ b/tests/test_unreadable_cache.php
@@ -7,7 +7,7 @@ if (strtoupper(substr(PHP_OS, 0, 3)) === 'WIN') {
 // Fix the working directory path explicitly
 chdir(__DIR__ . '/../');
 
-$cache_file = __DIR__ . '/../html_cache.html';
+$cache_file = sys_get_temp_dir() . '/html_cache.html';
 
 // Clean up any existing cache file
 if (file_exists($cache_file)) {

--- a/tests/test_xss.php
+++ b/tests/test_xss.php
@@ -61,7 +61,7 @@ $db = new MockMySQLi();
 // We need index.php not to require config.php again because require_once only loads once.
 // So if we include it here, index.php won't error out.
 // Let's test this strategy.
-@unlink(__DIR__ . '/../html_cache.html');
+@unlink(sys_get_temp_dir() . '/html_cache.html');
 @unlink(__DIR__ . '/../personalities_cache.json');
 ob_start();
 include __DIR__ . '/../index.php';


### PR DESCRIPTION
🎯 **What:** The cache file `html_cache.html` was previously being written to the web root (`__DIR__`), which made it directly accessible via HTTP requests. This patch moves the cache file to the system's temporary directory (`sys_get_temp_dir()`).

⚠️ **Risk:** Storing cache files in the web root exposes them to direct access. Even if the file only contains harmless HTML right now, this pattern can be dangerous if the cache mechanism is later used for sensitive data or if an attacker finds a way to manipulate the cached content (e.g., via cache poisoning), leading to potential information disclosure or stored XSS.

🛡️ **Solution:** The path for `$html_cache_file` in `index.php` was changed to `sys_get_temp_dir() . '/html_cache.html'`. This ensures the cache is stored securely on the filesystem outside of the web server's document root while maintaining the performance benefits of caching. All test scripts that reference the cache file were updated to use the new path to ensure tests pass.

---
*PR created automatically by Jules for task [10240642962305267233](https://jules.google.com/task/10240642962305267233) started by @cahyadsn*