### PR TITLE
🧪 [testing improvement] Add test for execute() failure in result query

### DIFF
--- a/tests/README.md
+++ b/tests/README.md
@@ -40,6 +40,7 @@ php tests/test_caching_performance.php
 php tests/test_security_headers.php
 php tests/test_result_fallback.php
 php tests/test_result_query_failure.php
+php tests/test_result_execute_failure.php
 php tests/test_html_cache_write_failure.php
 php tests/test_unreadable_cache.php
 ```
@@ -64,6 +65,7 @@ php tests/test_unreadable_cache.php
 | `test_security_headers.php` | Verifikasi `index.php` and `result.php` mengirim security headers (`X-Frame-Options`, `X-Content-Type-Options`) |
 | `test_result_fallback.php` | Test fallback pada `result.php`; verifikasi parameter default (15, 14, 15, 14) terikat dengan benar dalam single-execute query |
 | `test_result_query_failure.php` | Test penanganan kegagalan `get_result()` tanpa warning/error pada query single-execute |
+| `test_result_execute_failure.php` | Test penanganan kegagalan `execute()` pada single-execute query |
 | `test_html_cache_write_failure.php` | Verifikasi bahwa `error_log` dipanggil ketika gagal menulis ke file HTML cache (di-skip di Windows) |
 | `test_unreadable_cache.php` | Verifikasi bahwa file cache yang tidak bisa dibaca di-bypass dan HTML baru di-generate (di-skip di Windows) |
 

--- a/tests/test_result_execute_failure.php
+++ b/tests/test_result_execute_failure.php
@@ -1,0 +1,108 @@
+<?php
+
+try {
+    putenv('DB_PASS='); // Ensure no Exception from config.php missing pass
+    require_once __DIR__ . '/../conf/config.php';
+} catch (Throwable $e) {
+    // Suppress connection errors
+}
+
+class MockResult {
+    public function fetch_object() {
+        return null;
+    }
+}
+
+class MockStmt {
+    public $execute_count = 0;
+    public $get_result_count = 0;
+    public $bound_params = [];
+    public $val_d, $val_i, $val_s, $val_c;
+    public $def_d, $def_i, $def_s, $def_c;
+
+    public function bind_param($types, &$d, &$i, &$s, &$c, &$dd, &$di, &$ds, &$dc) {
+        $this->val_d = &$d;
+        $this->val_i = &$i;
+        $this->val_s = &$s;
+        $this->val_c = &$c;
+        $this->def_d = &$dd;
+        $this->def_i = &$di;
+        $this->def_s = &$ds;
+        $this->def_c = &$dc;
+    }
+
+    public function execute() {
+        $this->execute_count++;
+        // Capture values of references at the time of execution
+        $this->bound_params[] = [
+            $this->val_d, $this->val_i, $this->val_s, $this->val_c,
+            $this->def_d, $this->def_i, $this->def_s, $this->def_c
+        ];
+        return false; // Simulate execute failure
+    }
+
+    public function get_result() {
+        $this->get_result_count++;
+        // Return false simulating get_result failure from failed execute
+        return false;
+    }
+}
+
+class MockDb {
+    public $stmt;
+    public function prepare($sql) {
+        $this->stmt = new MockStmt();
+        return $this->stmt;
+    }
+}
+
+global $db;
+$db = new MockDb();
+
+$_POST['m'] = ['D'];
+$_POST['l'] = ['I'];
+
+$error_caught = false;
+set_error_handler(function($errno, $errstr, $errfile, $errline) use (&$error_caught) {
+    echo "ERROR/WARNING CAUGHT: $errstr in $errfile on line $errline\n";
+    $error_caught = true;
+});
+
+ob_start();
+try {
+    include __DIR__ . '/../result.php';
+} catch (Throwable $e) {
+    echo "THROWABLE CAUGHT: " . $e->getMessage() . "\n";
+    $error_caught = true;
+}
+$output = ob_get_clean();
+
+restore_error_handler();
+
+$failed = false;
+
+if ($error_caught) {
+    echo "FAIL: A warning or error was generated.\n";
+    $failed = true;
+} else {
+    echo "PASS: No warnings or errors were generated.\n";
+}
+
+if ($db->stmt->execute_count === 1) {
+    echo "PASS: execute() called once and handled return correctly.\n";
+} else {
+    echo "FAIL: execute() was called " . $db->stmt->execute_count . " times.\n";
+    $failed = true;
+}
+
+if (strpos($output, 'Data not found, check your database.') !== false) {
+    echo "PASS: HTML output contains error message when query fails.\n";
+} else {
+    echo "FAIL: HTML output does not contain expected error message. Output was: $output\n";
+    $failed = true;
+}
+
+if ($failed) {
+    exit(1);
+}
+exit(0);


### PR DESCRIPTION
🎯 **What:** Added a new test `test_result_execute_failure.php` to verify that the application handles a database statement `execute()` failure in `result.php` gracefully without throwing errors and by displaying an appropriate fallback message.
📊 **Coverage:** The test covers the scenario where the database prepared statement fails to execute properly, extending the safety net beyond just `get_result()` failures.
✨ **Result:** Test coverage for database query execution failures is improved, ensuring regressions are not introduced in the failure handling logic.

---
*PR created automatically by Jules for task [17763215219463678007](https://jules.google.com/task/17763215219463678007) started by @cahyadsn*