### PR TITLE
🧪 [testing improvement] Add edge case test for XSS in database output of result.php

### DIFF
--- a/tests/README.md
+++ b/tests/README.md
@@ -42,6 +42,7 @@ php tests/test_result_fallback.php
 php tests/test_result_query_failure.php
 php tests/test_html_cache_write_failure.php
 php tests/test_unreadable_cache.php
+php tests/test_result_xss.php
 ```
 
 ## Daftar Test
@@ -66,6 +67,7 @@ php tests/test_unreadable_cache.php
 | `test_result_query_failure.php` | Test penanganan kegagalan `get_result()` tanpa warning/error pada query single-execute |
 | `test_html_cache_write_failure.php` | Verifikasi bahwa `error_log` dipanggil ketika gagal menulis ke file HTML cache (di-skip di Windows) |
 | `test_unreadable_cache.php` | Verifikasi bahwa file cache yang tidak bisa dibaca di-bypass dan HTML baru di-generate (di-skip di Windows) |
+| `test_result_xss.php` | Test edge case untuk simulasi serangan XSS pada output hasil database |
 
 ## Environment Variables
 

--- a/tests/test_result_xss.php
+++ b/tests/test_result_xss.php
@@ -1,0 +1,93 @@
+<?php
+try {
+    putenv('DB_PASS='); // Ensure no Exception from config.php missing pass
+    require_once __DIR__ . '/../conf/config.php';
+} catch (Throwable $e) {
+    // Suppress connection errors
+}
+
+class MockResult {
+    private $data;
+    private $index = 0;
+
+    public function __construct($data) {
+        $this->data = $data;
+    }
+
+    public function fetch_object() {
+        if ($this->index < count($this->data)) {
+            return (object)$this->data[$this->index++];
+        }
+        return null;
+    }
+}
+
+class MockStmt {
+    public function bind_param(...$args) {}
+    public function execute() {}
+    public function get_result() {
+        return new MockResult([
+            [
+                'd' => "<script>alert('XSS-d')</script>",
+                'i' => "<script>alert('XSS-i')</script>",
+                's' => "<script>alert('XSS-s')</script>",
+                'c' => "<script>alert('XSS-c')</script>",
+                'name' => "<script>alert('XSS-name')</script>",
+                'emotions' => "<script>alert('XSS-emotions')</script>",
+                'goal' => "<script>alert('XSS-goal')</script>",
+                'judges_others' => "<script>alert('XSS-judges')</script>",
+                'influences_others' => "<script>alert('XSS-influences')</script>",
+                'organization_value' => "<script>alert('XSS-org')</script>",
+                'overuses' => "<script>alert('XSS-overuses')</script>",
+                'under_pressure' => "<script>alert('XSS-pressure')</script>",
+                'fear' => "<script>alert('XSS-fear')</script>",
+                'effectiveness' => "<script>alert('XSS-effectiveness')</script>",
+                'description' => "<script>alert('XSS-description')</script>"
+            ]
+        ]);
+    }
+}
+
+class MockMySQLi {
+    public function prepare($sql) {
+        return new MockStmt();
+    }
+}
+
+global $db;
+$db = new MockMySQLi();
+
+// Mock POST data for result.php
+$_POST['m'] = ['D'];
+$_POST['l'] = ['I'];
+
+ob_start();
+include __DIR__ . '/../result.php';
+$output = ob_get_clean();
+
+$fields = [
+    'd', 'i', 's', 'c', 'name', 'emotions', 'goal', 'judges', 'influences', 'org', 'overuses', 'pressure', 'fear', 'effectiveness', 'description'
+];
+
+$success = true;
+
+foreach ($fields as $field) {
+    $raw_payload = "<script>alert('XSS-$field')</script>";
+    $escaped_payload = htmlspecialchars($raw_payload, ENT_QUOTES, 'UTF-8');
+
+    if (strpos($output, $raw_payload) !== false) {
+        echo "FAIL: $field XSS payload was NOT escaped!\n";
+        $success = false;
+    } elseif (strpos($output, $escaped_payload) !== false) {
+        echo "PASS: $field XSS payload was escaped.\n";
+    } else {
+        echo "FAIL: $field XSS payload was not found at all!\n";
+        $success = false;
+    }
+}
+
+if (!$success) {
+    exit(1);
+}
+
+exit(0);


### PR DESCRIPTION
🎯 **What:** The testing gap addressed is the lack of edge-case tests validating that database outputs dynamically rendered in `result.php` are resilient against Cross-Site Scripting (XSS).

📊 **Coverage:** The new test (`tests/test_result_xss.php`) mocks the database connection and injects XSS payloads into all dynamic fields returned by the query ('d', 'i', 's', 'c', 'name', 'emotions', 'goal', 'judges_others', 'influences_others', 'organization_value', 'overuses', 'under_pressure', 'fear', 'effectiveness', 'description'). It asserts that the rendered HTML only contains `htmlspecialchars()` escaped variants of the payloads and no raw script tags.

✨ **Result:** Test coverage for XSS vectors has increased, ensuring that any future refactoring of `result.php` will be caught if it inadvertently removes or misconfigures the HTML escaping logic for database-derived content.

---
*PR created automatically by Jules for task [1933356534548117219](https://jules.google.com/task/1933356534548117219) started by @cahyadsn*