### PR TITLE
🧹 Remove unused array keys in result computation

### DIFF
--- a/result.php
+++ b/result.php
@@ -62,11 +62,7 @@ if(isset($_POST['m']) && isset($_POST['l']) && is_array($_POST['m']) && is_array
   foreach($aspect as $a){
     $m = $most[$a] ?? 0;
     $l = $least[$a] ?? 0;
-    $result[$a] = [
-        'most' => $m,
-        'least' => $l,
-        'change' => $m - $l
-    ];
+    $result[$a] = $m - $l;
   }
 
   require_once 'conf/config.php';
@@ -99,10 +95,10 @@ if(isset($_POST['m']) && isset($_POST['l']) && is_array($_POST['m']) && is_array
 	$stmt = $db->prepare($sql);
 	$data = null;
 	if ($stmt) {
-		$val_d = $result['D']['change'];
-		$val_i = $result['I']['change'];
-		$val_s = $result['S']['change'];
-		$val_c = $result['C']['change'];
+		$val_d = $result['D'];
+		$val_i = $result['I'];
+		$val_s = $result['S'];
+		$val_c = $result['C'];
 		$def_d = DEFAULT_VAL_D;
 		$def_i = DEFAULT_VAL_I;
 		$def_s = DEFAULT_VAL_S;


### PR DESCRIPTION
🎯 **What:** Removed unused `'most'` and `'least'` array keys from the computed `$result` array inside `result.php`. Transformed the array structure to store scalar result values directly, and updated downstream usages accordingly.
💡 **Why:** By reducing the `$result` assignments from multi-dimensional arrays with dead data to scalar assignments, memory overhead is decreased. The code becomes cleaner, simplifying how results are read downstream. 
✅ **Verification:** Ran the full custom PHP ad-hoc test suite (`tests/test_*.php`) ensuring all logic continued to behave properly. Reviewed code modifications with the internal static analyzer bot which verified completeness and safety.
✨ **Result:** A more legible, streamlined array allocation avoiding duplicate keys that are never read.

---
*PR created automatically by Jules for task [11034911361427137810](https://jules.google.com/task/11034911361427137810) started by @cahyadsn*