### PR TITLE
🧹 Fix unreachable condition for DB_PASS check

### DIFF
--- a/conf/config.php
+++ b/conf/config.php
@@ -35,7 +35,7 @@ require_once __DIR__ . '/autoload_env.php';
 //-- database configuration
 $dbhost = getenv('DB_HOST') ?: 'localhost';
 $dbuser = getenv('DB_USER') ?: 'root';
-$dbpass = getenv('DB_PASS') ?: '';
+$dbpass = getenv('DB_PASS');
 if ($dbpass === false) {
     error_log('DB_PASS environment variable is required.');
     exit('Database configuration error.');


### PR DESCRIPTION
🎯 **What:** Removed the empty string default `?: ''` from the `DB_PASS` configuration logic in `conf/config.php` so that a missing environment variable correctly sets `$dbpass` to `false`.

💡 **Why:** The previous logic set `$dbpass` to `''` when the environment variable was missing, making the subsequent `if ($dbpass === false)` check impossible to reach. Fixing this restores the intended error logging and safe exit when database configuration is fundamentally flawed.

✅ **Verification:** Verified by inspecting the patch and running the full ad-hoc test suite (`tests/test_*.php`) which confirmed the intended error states are successfully handled. No new regressions were introduced.

✨ **Result:** The code correctly enforces the existence of `DB_PASS`, improving clarity and properly executing the defensive error handling logic.

---
*PR created automatically by Jules for task [14542532445537773416](https://jules.google.com/task/14542532445537773416) started by @cahyadsn*