### PR TITLE
🧹 Extract duplicated security headers to a central file

### DIFF
--- a/conf/headers.php
+++ b/conf/headers.php
@@ -1,0 +1,6 @@
+<?php
+if (!headers_sent()) {
+    header('X-Frame-Options: DENY');
+    header('X-Content-Type-Options: nosniff');
+    header("Content-Security-Policy: default-src 'self';");
+}

--- a/index.php
+++ b/index.php
@@ -31,11 +31,7 @@ SOFTWARE.
 copyright (c) 2026 by cahya dsn; cahyadsn@gmail.com
 ================================================================================
 */
-if (!headers_sent()) {
-    header('X-Frame-Options: DENY');
-    header('X-Content-Type-Options: nosniff');
-    header("Content-Security-Policy: default-src 'self';");
-}
+require_once __DIR__ . '/conf/headers.php';
 $html_cache_file = sys_get_temp_dir() . '/html_cache.html';
 $html_content = false;
 $cols  		= 4;	//<-- number of columns

--- a/result.php
+++ b/result.php
@@ -31,11 +31,7 @@ SOFTWARE.
 copyright (c) 2026 by cahya dsn; cahyadsn@gmail.com
 ================================================================================
 */
-if (!headers_sent()) {
-    header('X-Frame-Options: DENY');
-    header('X-Content-Type-Options: nosniff');
-    header("Content-Security-Policy: default-src 'self';");
-}
+require_once __DIR__ . '/conf/headers.php';
 const DEFAULT_VAL_D = 15;
 const DEFAULT_VAL_I = 14;
 const DEFAULT_VAL_S = 15;

--- a/tests/test_security_headers.php
+++ b/tests/test_security_headers.php
@@ -1,25 +1,29 @@
 <?php
-$files = ['index.php', 'result.php'];
 $passed = true;
+$header_content = file_get_contents(__DIR__ . '/../conf/headers.php');
+if (strpos($header_content, "header('X-Frame-Options: DENY');") === false) {
+    echo "Missing X-Frame-Options in conf/headers.php\n";
+    $passed = false;
+}
+if (strpos($header_content, "header('X-Content-Type-Options: nosniff');") === false) {
+    echo "Missing X-Content-Type-Options in conf/headers.php\n";
+    $passed = false;
+}
+if (strpos($header_content, "header(\"Content-Security-Policy: default-src 'self';\");") === false) {
+    echo "Missing Content-Security-Policy in conf/headers.php\n";
+    $passed = false;
+}
+
+$files = ['index.php', 'result.php'];
 foreach ($files as $file) {
     $content = file_get_contents(__DIR__ . '/../' . $file);
-    if (strpos($content, "header('X-Frame-Options: DENY');") === false) {
-        echo "Missing X-Frame-Options in $file\n";
-        $passed = false;
-    }
-    if (strpos($content, "header('X-Content-Type-Options: nosniff');") === false) {
-        echo "Missing X-Content-Type-Options in $file\n";
-        $passed = false;
-    }
-    if (strpos($content, "header(\"Content-Security-Policy: default-src 'self';\");") === false) {
-        echo "Missing Content-Security-Policy in $file\n";
+    if (strpos($content, "require_once __DIR__ . '/conf/headers.php';") === false) {
+        echo "Missing require_once headers.php in $file\n";
         $passed = false;
     }
 }
 if ($passed) {
     echo "Security headers test passed.\n";
-    // We shouldn't use exit(0) inside test files if we evaluate via ad-hoc loop
 } else {
     echo "Security headers test failed.\n";
-    // exit(1);
 }


### PR DESCRIPTION
🎯 **What:** Extracted duplicated security headers logic (`X-Frame-Options`, `X-Content-Type-Options`, `Content-Security-Policy`) from `index.php` and `result.php` into a new reusable configuration file `conf/headers.php`. Replaced the inline logic in both entry points with a `require_once __DIR__ . '/conf/headers.php';` statement. Also updated `tests/test_security_headers.php` to accommodate this new structure.

💡 **Why:** To improve code maintainability and readability by adhering to the DRY (Don't Repeat Yourself) principle. Having security headers centralized makes it easier to update policies in a single location across all entry points in the application.

✅ **Verification:** Verified the creation of the new file and modifications via local file inspections. Updated the `test_security_headers.php` testing script to assert the presence of headers in the new config file and the inclusion statement in the entry files. Ran the entire ad-hoc test suite successfully to ensure no regressions.

✨ **Result:** A cleaner codebase with centralized security headers logic, eliminating duplication and improving maintainability.

---
*PR created automatically by Jules for task [12971462991496292618](https://jules.google.com/task/12971462991496292618) started by @cahyadsn*