### PR TITLE
🔒 Fix Uncaught Global Exception Exposure in config.php

### DIFF
--- a/index.php
+++ b/index.php
@@ -43,11 +43,15 @@ if (is_readable($html_cache_file)) {
 
 if ($html_content === false) {
     // Lazy load the database connection only on cache miss
-    require_once 'conf/config.php';
+    try {
+        require_once 'conf/config.php';
+    } catch (Exception $e) {
+        error_log($e->getMessage());
+    }
 
     //-- query data from database
     $sql='SELECT * FROM personalities ORDER BY no ASC';
-    $result=$db->query($sql);
+    $result = isset($db) ? $db->query($sql) : false;
     $data=array();
     if ($result) {
         while($row=$result->fetch_object()) {

--- a/result.php
+++ b/result.php
@@ -61,7 +61,11 @@ if(isset($_POST['m']) && isset($_POST['l']) && is_array($_POST['m']) && is_array
     $result[$a] = $m - $l;
   }
 
-  require_once 'conf/config.php';
+  try {
+      require_once 'conf/config.php';
+  } catch (Exception $e) {
+      error_log($e->getMessage());
+  }
     // Bolt optimization: Replaced cross-joined derived tables with direct subqueries to prevent temporary table creation
     // and Cartesian products. This reduces CPU/memory usage and allows utilizing primary key indexes effectively.
     $sql="
@@ -88,7 +92,7 @@ if(isset($_POST['m']) && isset($_POST['l']) && is_array($_POST['m']) && is_array
         ) AS default_result
         ORDER BY priority ASC
         LIMIT 1";
-	$stmt = $db->prepare($sql);
+	$stmt = isset($db) ? $db->prepare($sql) : false;
 	$data = null;
 	if ($stmt) {
 		$val_d = $result['D'];


### PR DESCRIPTION
🎯 **What:** 
Fixed a vulnerability where database connection failures in `conf/config.php` threw uncaught exceptions that bubbled up and caused fatal errors in `index.php` and `result.php`.

⚠️ **Risk:** 
If left unfixed, an uncaught exception on database failure causes a 500 Internal Server Error and may expose sensitive information (such as stack traces or file paths) to users, depending on the PHP error reporting configuration.

🛡️ **Solution:** 
Wrapped the `require_once 'conf/config.php'` statements in `try...catch` blocks to catch and log the exceptions via `error_log()`. Additionally, modified the subsequent `$db` usages (e.g., `$db->query` and `$db->prepare`) to only execute if `$db` is set (`isset($db)`), defaulting to `false` otherwise. This allows the application to gracefully skip database operations on failure and display a generic "Data not found" or "Error loading data" UI message.

---
*PR created automatically by Jules for task [1883558420819638750](https://jules.google.com/task/1883558420819638750) started by @cahyadsn*