### PR TITLE
🔒 Fix database password validation logic

### DIFF
--- a/conf/config.php
+++ b/conf/config.php
@@ -36,7 +36,7 @@ require_once __DIR__ . '/autoload_env.php';
 $dbhost = getenv('DB_HOST') ?: 'localhost';
 $dbuser = getenv('DB_USER') ?: 'root';
 $dbpass = getenv('DB_PASS');
-if ($dbpass === false) {
+if ($dbpass === false || $dbpass === '') {
     error_log('DB_PASS environment variable is required.');
     exit('Database configuration error.');
 }

--- a/tests/test_config.php
+++ b/tests/test_config.php
@@ -6,9 +6,9 @@ $failed = false;
 // NOTE: DB_PASS is required now so it will throw an exception if completely missing.
 // We set DB_PASS to an empty string to bypass the strict security exception
 // so that we can verify the fallback default values for the other variables.
-putenv('DB_HOST'); putenv('DB_USER'); putenv('DB_PASS='); putenv('DB_NAME');
+putenv('DB_HOST'); putenv('DB_USER'); putenv('DB_PASS=dummy'); putenv('DB_NAME');
 try { @include __DIR__ . '/../conf/config.php'; } catch (Throwable $e) {}
-if ($dbhost !== 'localhost' || $dbuser !== 'root' || $dbpass !== '' || $dbname !== 'test') {
+if ($dbhost !== 'localhost' || $dbuser !== 'root' || $dbpass !== 'dummy' || $dbname !== 'test') {
     echo "FAIL: Expected defaults.\n";
     $failed = true;
 }

--- a/tests/test_db_connection_failure.php
+++ b/tests/test_db_connection_failure.php
@@ -5,7 +5,7 @@ echo "Running DB connection failure test...\n";
 // Set invalid host to simulate connection error
 putenv('DB_HOST=invalid_host_12345');
 putenv('DB_USER=test');
-putenv('DB_PASS=test');
+putenv('DB_PASS=dummy');
 putenv('DB_NAME=test');
 
 $exceptionThrown = false;

--- a/tests/test_db_persistent.php
+++ b/tests/test_db_persistent.php
@@ -1,5 +1,5 @@
 <?php
-putenv('DB_PASS=');
+putenv('DB_PASS=dummy');
 
 $start = microtime(true);
 for ($i = 0; $i < 100; $i++) {

--- a/tests/test_exception_leak.php
+++ b/tests/test_exception_leak.php
@@ -21,7 +21,7 @@ class MockMySQLi {
     }
 }
 
-putenv('DB_HOST=127.0.0.1');
+putenv('DB_HOST=127.0.0.1'); putenv('DB_PASS=dummy');
 
 try {
     @include __DIR__ . '/../conf/config.php';

--- a/tests/test_getenv.php
+++ b/tests/test_getenv.php
@@ -1,0 +1,5 @@
+<?php
+putenv('DB_PASS=dummy');
+var_dump(getenv('DB_PASS'));
+putenv('DB_PASS'); // remove
+var_dump(getenv('DB_PASS'));

--- a/tests/test_html_cache_write_failure.php
+++ b/tests/test_html_cache_write_failure.php
@@ -7,7 +7,7 @@ $log_file = __DIR__ . '/test_error.log';
 @unlink($log_file);
 ini_set('error_log', $log_file);
 
-putenv('DB_PASS='); // Ensure DB_PASS is set to avoid exceptions from config.php
+putenv('DB_PASS=dummy'); // Ensure DB_PASS is set to avoid exceptions from config.php
 
 // Mock DB connection
 class MockMySQLiResult {

--- a/tests/test_index_cache_read_failure.php
+++ b/tests/test_index_cache_read_failure.php
@@ -72,7 +72,7 @@ class FailingFileWrapper {
     public function dir_rewinddir() { rewinddir($this->dh); }
 }
 
-putenv('DB_PASS='); // Ensure no config error
+putenv('DB_PASS=dummy'); // Ensure no config error
 
 $tmp_dir = null;
 try {

--- a/tests/test_index_empty_result.php
+++ b/tests/test_index_empty_result.php
@@ -1,5 +1,5 @@
 <?php
-putenv('DB_PASS='); // Avoid Exception
+putenv('DB_PASS=dummy'); // Avoid Exception
 
 class MockMySQLiResultEmpty {
     public function fetch_object() {

--- a/tests/test_index_query_failure.php
+++ b/tests/test_index_query_failure.php
@@ -6,6 +6,7 @@ class MockMySQLi {
     }
 }
 
+putenv('DB_PASS=dummy');
 try {
     @include __DIR__ . '/../conf/config.php';
 } catch (Throwable $e) {}

--- a/tests/test_invalid_dimensions.php
+++ b/tests/test_invalid_dimensions.php
@@ -1,7 +1,7 @@
 <?php
 
 try {
-    putenv('DB_PASS='); // Ensure no Exception from config.php missing pass
+    putenv('DB_PASS=dummy'); // Ensure no Exception from config.php missing pass
     require_once __DIR__ . '/../conf/config.php';
 } catch (Throwable $e) {
     // Suppress connection errors

--- a/tests/test_prepare_false.php
+++ b/tests/test_prepare_false.php
@@ -1,6 +1,6 @@
 <?php
 try {
-    putenv('DB_PASS='); // Ensure no Exception from config.php missing pass
+    putenv('DB_PASS=dummy'); // Ensure no Exception from config.php missing pass
     require_once __DIR__ . '/../conf/config.php';
 } catch (Throwable $e) {
     // Suppress connection errors

--- a/tests/test_result_execute_failure.php
+++ b/tests/test_result_execute_failure.php
@@ -1,7 +1,7 @@
 <?php
 
 try {
-    putenv('DB_PASS='); // Ensure no Exception from config.php missing pass
+    putenv('DB_PASS=dummy'); // Ensure no Exception from config.php missing pass
     require_once __DIR__ . '/../conf/config.php';
 } catch (Throwable $e) {
     // Suppress connection errors

--- a/tests/test_result_fallback.php
+++ b/tests/test_result_fallback.php
@@ -1,7 +1,7 @@
 <?php
 
 try {
-    putenv('DB_PASS='); // Ensure no Exception from config.php missing pass
+    putenv('DB_PASS=dummy'); // Ensure no Exception from config.php missing pass
     require_once __DIR__ . '/../conf/config.php';
 } catch (Throwable $e) {
     // Suppress connection errors

--- a/tests/test_result_query_failure.php
+++ b/tests/test_result_query_failure.php
@@ -1,7 +1,7 @@
 <?php
 
 try {
-    putenv('DB_PASS='); // Ensure no Exception from config.php missing pass
+    putenv('DB_PASS=dummy'); // Ensure no Exception from config.php missing pass
     require_once __DIR__ . '/../conf/config.php';
 } catch (Throwable $e) {
     // Suppress connection errors

--- a/tests/test_result_xss.php
+++ b/tests/test_result_xss.php
@@ -1,6 +1,6 @@
 <?php
 try {
-    putenv('DB_PASS='); // Ensure no Exception from config.php missing pass
+    putenv('DB_PASS=dummy'); // Ensure no Exception from config.php missing pass
     require_once __DIR__ . '/../conf/config.php';
 } catch (Throwable $e) {
     // Suppress connection errors

--- a/tests/test_unreadable_cache.php
+++ b/tests/test_unreadable_cache.php
@@ -28,7 +28,7 @@ file_put_contents($cache_file, 'CACHE_HIT');
 // Make it unreadable
 chmod($cache_file, 0000);
 
-putenv('DB_PASS='); // Ensure no config error
+putenv('DB_PASS=dummy'); // Ensure no config error
 
 // Mock the db connection before including index.php
 $tmp_dir = null;

--- a/tests/test_xss.php
+++ b/tests/test_xss.php
@@ -44,7 +44,7 @@ class MockMySQLi {
 }
 
 // Override connection settings
-putenv('DB_HOST=127.0.0.1');
+putenv('DB_HOST=127.0.0.1'); putenv('DB_PASS=dummy');
 
 // Instead of rewriting config.php, we can simply override the $db variable AFTER require_once 'config.php'.
 // However, 'config.php' will attempt to connect, which will fail if MySQL is not running.


### PR DESCRIPTION
🎯 **What:** The vulnerability fixed was that the application accepted an empty string (`''`) as a valid database password in `conf/config.php` because `getenv()` returns an empty string (not `false`) if the variable is set but empty.
⚠️ **Risk:** A malicious user or misconfiguration could set `DB_PASS=` and bypass the required password check, potentially connecting as a database root user without a password, causing a massive data compromise.
🛡️ **Solution:** Modified the check in `conf/config.php` to explicitly verify against an empty string: `if ($dbpass === false || $dbpass === '')`. Updated the custom test suite to use a dummy password to bypass this strict check properly where needed.

---
*PR created automatically by Jules for task [2944670126987823676](https://jules.google.com/task/2944670126987823676) started by @cahyadsn*