### PR TITLE
🧪 Add tests for loadEnv edge cases in conf/autoload_env.php

### DIFF
--- a/tests/test_autoload_env.php
+++ b/tests/test_autoload_env.php
@@ -1,0 +1,97 @@
+<?php
+require_once __DIR__ . '/../conf/autoload_env.php';
+
+$failed = false;
+
+$unreadableFile = __DIR__ . '/unreadable.env';
+$envFile = __DIR__ . '/test.env';
+
+// Guarantee cleanup
+register_shutdown_function(function() use ($unreadableFile, $envFile) {
+    if (file_exists($unreadableFile)) {
+        chmod($unreadableFile, 0644);
+        unlink($unreadableFile);
+    }
+    if (file_exists($envFile)) {
+        unlink($envFile);
+    }
+});
+
+// 1. Test unreadable file
+touch($unreadableFile);
+chmod($unreadableFile, 0000);
+if (!is_readable($unreadableFile)) {
+    loadEnv($unreadableFile); // Should not throw error
+}
+
+// 2. Test missing file
+loadEnv(__DIR__ . '/nonexistent.env'); // Should not throw error
+
+// 3. Test various edge cases in valid file
+$envContent = <<<ENV
+# This is a comment
+
+NORMAL_KEY=normal_value
+  SPACED_KEY = spaced_value
+QUOTED_KEY="quoted_value"
+SINGLE_QUOTED_KEY='single_quoted_value'
+MALFORMED_LINE
+MALFORMED_LINE_NO_EQUALS
+EMPTY_VALUE=
+ENV;
+
+file_put_contents($envFile, $envContent);
+
+// Set an existing env var to test it doesn't get overwritten
+putenv('EXISTING_KEY=original_value');
+file_put_contents($envFile, "\nEXISTING_KEY=new_value\n", FILE_APPEND);
+
+loadEnv($envFile);
+
+// Assertions
+if (getenv('NORMAL_KEY') !== 'normal_value') {
+    echo "FAIL: NORMAL_KEY not set correctly\n";
+    $failed = true;
+}
+
+if (getenv('SPACED_KEY') !== 'spaced_value') {
+    echo "FAIL: SPACED_KEY not set correctly\n";
+    $failed = true;
+}
+
+if (getenv('QUOTED_KEY') !== 'quoted_value') {
+    echo "FAIL: QUOTED_KEY not set correctly\n";
+    $failed = true;
+}
+
+if (getenv('SINGLE_QUOTED_KEY') !== 'single_quoted_value') {
+    echo "FAIL: SINGLE_QUOTED_KEY not set correctly\n";
+    $failed = true;
+}
+
+if (getenv('EMPTY_VALUE') !== '') {
+    echo "FAIL: EMPTY_VALUE not set correctly (got " . var_export(getenv('EMPTY_VALUE'), true) . ")\n";
+    $failed = true;
+}
+
+if (getenv('EXISTING_KEY') !== 'original_value') {
+    echo "FAIL: EXISTING_KEY was overwritten\n";
+    $failed = true;
+}
+
+if (getenv('MALFORMED_LINE') !== false) {
+    echo "FAIL: MALFORMED_LINE was set\n";
+    $failed = true;
+}
+
+if (getenv('MALFORMED_LINE_NO_EQUALS') !== false) {
+    echo "FAIL: MALFORMED_LINE_NO_EQUALS was set\n";
+    $failed = true;
+}
+
+if (!$failed) {
+    echo "PASS\n";
+    exit(0);
+} else {
+    exit(1);
+}


### PR DESCRIPTION
🎯 **What:** The testing gap addressed
The `loadEnv` function in `conf/autoload_env.php` handles reading `.env` files and extracting key-value pairs. It lacked coverage for various edge cases, such as missing files, unreadable files, comments, and most importantly, malformed lines (e.g., lines missing an `=` sign). This PR introduces a test script that validates the function's resilience against these edge cases.

📊 **Coverage:** What scenarios are now tested
- Unreadable files (ensuring no error is thrown and handled safely)
- Missing files (ensuring no error is thrown)
- Normal keys with standard values
- Keys and values with leading/trailing spaces (should be trimmed)
- Double-quoted and single-quoted values (quotes are correctly kept by `loadEnv`'s current logic or handled)
- Malformed lines missing an `=` sign (ensuring they are skipped and do not set invalid variables)
- Empty values
- Keys that are already set in the environment (ensuring they are not overwritten)

✨ **Result:** The improvement in test coverage
The code now has a concrete, deterministic test suite that explicitly validates how `loadEnv` handles edge cases without halting execution. The tests use safe temporary files, cleanup via `register_shutdown_function()`, and correct filesystem mock logic for CI/root environments. This creates a solid safety net against future regressions in the configuration loading mechanism.

---
*PR created automatically by Jules for task [9127853436116770748](https://jules.google.com/task/9127853436116770748) started by @cahyadsn*