### PR TITLE
🔒 Fix insecure temporary file creation in shared hosting environments

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,4 +6,5 @@ vendor/
 composer.lock
 /html_cache.html
 GEMINI.md
-.env
+.env
+cache/

--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@ This project is built using a lightweight and highly optimized architecture desi
   * **Single Round-trip Fallbacks**: Optimized data retrieval utilizing SQL `UNION ALL` to resolve pattern records and application fallbacks in a single database query.
   * **Prepared Statements**: Secure parameter binding utilizing mysqli prepared statements.
 * **Caching & Performance Optimization**:
-  * **HTML File Caching**: Pre-compiles the heavily nested rendering loop output to an HTML cache file (`html_cache.html`) in the system temporary directory (to prevent direct HTTP access), yielding a ~98% speedup.
+  * **HTML File Caching**: Pre-compiles the heavily nested rendering loop output to an HTML cache file (`html_cache.html`) in the local `cache/` directory (protected via `.htaccess` to prevent direct HTTP access), yielding a ~98% speedup.
   * **Filesystem Call Reductions**: Uses `is_readable()` to perform cache-hit checks in one step, bypassing redundant `file_exists()` checks.
   * **Loop & Memory Optimizations**: Minimized array allocations and nested calculations inside loops.
 * **Security & Hardening**:
@@ -148,7 +148,7 @@ This project is built using a lightweight and highly optimized architecture desi
 
 ### Recent Updates (2026-07-26)
 - **Security & Caching**:
-  - Moved `html_cache.html` out of the web root into the system temporary directory (`sys_get_temp_dir()`) to prevent direct public HTTP access.
+  - Moved `html_cache.html` out of the web root into the local `cache/` directory (protected via `.htaccess`) to prevent direct public HTTP access.
   - Implemented `Content-Security-Policy: default-src 'self';` header on both `index.php` and `result.php`.
   - Redacted the database connection exception context (stripped internal PHP exception chains) to prevent accidental database credential leaks in debug logs.
   - Removed redundant `file_exists()` checks before checking `is_readable()` when resolving HTML cache hits.

--- a/cache/.htaccess
+++ b/cache/.htaccess
@@ -1,0 +1,2 @@
+Require all denied
+Deny from all

--- a/index.php
+++ b/index.php
@@ -32,7 +32,11 @@ copyright (c) 2026 by cahya dsn; cahyadsn@gmail.com
 ================================================================================
 */
 require_once __DIR__ . '/conf/headers.php';
-$html_cache_file = sys_get_temp_dir() . '/html_cache.html';
+$cache_dir = __DIR__ . '/cache';
+if (!is_dir($cache_dir)) {
+    mkdir($cache_dir, 0755, true);
+}
+$html_cache_file = $cache_dir . '/html_cache.html';
 $html_content = false;
 $cols  		= 4;	//<-- number of columns
 

--- a/tests/test_html_cache_write_failure.php
+++ b/tests/test_html_cache_write_failure.php
@@ -24,7 +24,7 @@ try { @include __DIR__ . '/../conf/config.php'; } catch (Throwable $e) {}
 global $db;
 $db = new MockMySQLi();
 
-$cache_file = sys_get_temp_dir() . '/html_cache.html';
+$cache_file = __DIR__ . '/../cache/html_cache.html';
 system('rm -rf ' . escapeshellarg($cache_file));
 touch($cache_file);
 chmod($cache_file, 0000); // No permissions. This makes is_readable() false, and file_put_contents() fail.

--- a/tests/test_index_cache_read_failure.php
+++ b/tests/test_index_cache_read_failure.php
@@ -2,7 +2,7 @@
 // Fix working directory
 chdir(__DIR__ . '/../');
 
-$cache_file = sys_get_temp_dir() . '/html_cache.html';
+$cache_file = __DIR__ . '/../cache/html_cache.html';
 
 class FailingFileWrapper {
     public $context;

--- a/tests/test_index_empty_result.php
+++ b/tests/test_index_empty_result.php
@@ -20,7 +20,7 @@ try {
 global $db;
 $db = new MockMySQLiEmpty();
 
-@unlink(sys_get_temp_dir() . '/html_cache.html');
+@unlink(__DIR__ . '/../cache/html_cache.html');
 
 ob_start();
 include __DIR__ . '/../index.php';

--- a/tests/test_index_query_failure.php
+++ b/tests/test_index_query_failure.php
@@ -14,7 +14,7 @@ try {
 global $db;
 $db = new MockMySQLi();
 
-@unlink(sys_get_temp_dir() . '/html_cache.html');
+@unlink(__DIR__ . '/../cache/html_cache.html');
 
 ob_start();
 include __DIR__ . '/../index.php';

--- a/tests/test_lazy_db.php
+++ b/tests/test_lazy_db.php
@@ -1,6 +1,6 @@
 <?php
 // We test if the database connection is avoided when cache is hit.
-$cache_file = sys_get_temp_dir() . '/html_cache.html';
+$cache_file = __DIR__ . '/../cache/html_cache.html';
 
 // Create a dummy valid html cache (enough to suppress warnings)
 $dummy_data = [];

--- a/tests/test_unreadable_cache.php
+++ b/tests/test_unreadable_cache.php
@@ -7,7 +7,7 @@ if (strtoupper(substr(PHP_OS, 0, 3)) === 'WIN') {
 // Ensure the working directory is correct
 chdir(__DIR__ . '/../');
 
-$cache_file = sys_get_temp_dir() . '/html_cache.html';
+$cache_file = __DIR__ . '/../cache/html_cache.html';
 
 // Clean up any existing cache file
 if (file_exists($cache_file)) {

--- a/tests/test_xss.php
+++ b/tests/test_xss.php
@@ -61,7 +61,7 @@ $db = new MockMySQLi();
 // We need index.php not to require config.php again because require_once only loads once.
 // So if we include it here, index.php won't error out.
 // Let's test this strategy.
-@unlink(sys_get_temp_dir() . '/html_cache.html');
+@unlink(__DIR__ . '/../cache/html_cache.html');
 @unlink(__DIR__ . '/../personalities_cache.json');
 ob_start();
 include __DIR__ . '/../index.php';


### PR DESCRIPTION
🎯 **What:** The HTML cache file (`html_cache.html`) was being stored in the shared system temporary directory (`sys_get_temp_dir()`). The fix moves the cache file to a local `cache/` directory within the project, protected by a `.htaccess` file.

⚠️ **Risk:** Storing cache files in a shared system temporary directory on shared hosting environments exposes the application to security vulnerabilities such as symlink attacks, local file overwrite, and potential cache poisoning if other local users on the same machine can manipulate the shared `/tmp` space.

🛡️ **Solution:** Modified `index.php` to use `__DIR__ . '/cache/html_cache.html'`. Implemented logic to automatically create the `cache/` directory on first run. To maintain the original security posture of preventing public HTTP access to the cached file, a `.htaccess` file containing `Require all denied` and `Deny from all` is placed inside the `cache/` directory. Updated tests, `.gitignore`, and `README.md` to reflect these changes. All existing tests pass successfully.

---
*PR created automatically by Jules for task [13790973703421942785](https://jules.google.com/task/13790973703421942785) started by @cahyadsn*