### PR TITLE
🧹 refactor(result): use early return pattern to reduce nesting

### DIFF
--- a/result.php
+++ b/result.php
@@ -45,8 +45,15 @@ const DEFAULT_VAL_C = 14;
   </head>
   <body>
 <?php
-if(isset($_POST['m']) && isset($_POST['l']) && is_array($_POST['m']) && is_array($_POST['l'])){
-  // Bolt optimization: Pre-initialize aspect counts and use direct hash lookup (isset)
+if (!(isset($_POST['m']) && isset($_POST['l']) && is_array($_POST['m']) && is_array($_POST['l']))) {
+?>
+  </body>
+</html>
+<?php
+    return;
+}
+
+// Bolt optimization: Pre-initialize aspect counts and use direct hash lookup (isset)
   // instead of dynamic keys and null coalescing, avoiding a secondary extraction loop (~25% speedup).
   $most = ['D' => 0, 'I' => 0, 'S' => 0, 'C' => 0];
   foreach ($_POST['m'] as $v) if (is_scalar($v) && isset($most[$v])) $most[$v]++;
@@ -145,7 +152,6 @@ if(isset($_POST['m']) && isset($_POST['l']) && is_array($_POST['m']) && is_array
     </div>
 <?php
 	}
-}
 ?>    
   </body>
 </html>


### PR DESCRIPTION
🎯 **What:** Addressed deep nesting of the main execution logic in `result.php:48`.
💡 **Why:** By applying the 'return early' pattern when the required `$_POST` variables are missing or invalid, we remove a massive conditional block that wrapped nearly the entire file. This reduces indentation and improves the overall readability and maintainability of the script.
✅ **Verification:** Verified by generating HTML outputs before and after the change with both valid and invalid POST configurations to ensure exact matching. Also passed the full custom test suite without regressions.
✨ **Result:** A flatter, easier to read codebase with identical functional behavior.

---
*PR created automatically by Jules for task [8904735448692432974](https://jules.google.com/task/8904735448692432974) started by @cahyadsn*