### PR TITLE
🔒 Fix Path Exposure via Unsuppressed Warnings

### DIFF
--- a/index.php
+++ b/index.php
@@ -34,7 +34,7 @@ copyright (c) 2026 by cahya dsn; cahyadsn@gmail.com
 require_once __DIR__ . '/conf/headers.php';
 $cache_dir = __DIR__ . '/cache';
 if (!is_dir($cache_dir)) {
-    mkdir($cache_dir, 0755, true);
+    @mkdir($cache_dir, 0755, true);
 }
 $html_cache_file = $cache_dir . '/html_cache.html';
 $html_content = false;
@@ -228,7 +228,7 @@ if ($html_content === false) {
       echo implode('', $html);
     $html_content = ob_get_clean();
     if ($result) {
-        if (file_put_contents($html_cache_file, $html_content, LOCK_EX) === false) {
+        if (@file_put_contents($html_cache_file, $html_content, LOCK_EX) === false) {
             error_log("Failed to write to HTML cache file: $html_cache_file");
         }
     }


### PR DESCRIPTION
🎯 **What:** Added the `@` error control operator to `mkdir()` and `file_put_contents()` calls in `index.php`.
⚠️ **Risk:** If these filesystem operations fail (e.g., due to permissions issues), PHP emits warnings that could expose sensitive absolute file paths to end users, potentially aiding an attacker.
🛡️ **Solution:** Suppressing the warnings prevents path exposure. Any `false` return from `file_put_contents` is still correctly caught and securely logged via `error_log()` without leaking information to the user.

---
*PR created automatically by Jules for task [164484616408420574](https://jules.google.com/task/164484616408420574) started by @cahyadsn*