### PR TITLE
🔒 Remove insecure default 'root' fallback for DB_USER

### DIFF
--- a/conf/config.php
+++ b/conf/config.php
@@ -34,7 +34,7 @@ copyright (c) 2026 by cahya dsn; cahyadsn@gmail.com
 require_once __DIR__ . '/autoload_env.php';
 //-- database configuration
 $dbhost = getenv('DB_HOST') ?: 'localhost';
-$dbuser = getenv('DB_USER') ?: 'root';
+$dbuser = getenv('DB_USER') ?: '';
 $dbpass = getenv('DB_PASS');
 if ($dbpass === false || $dbpass === '') {
     error_log('DB_PASS environment variable is required.');

--- a/tests/test_config.php
+++ b/tests/test_config.php
@@ -8,7 +8,7 @@ $failed = false;
 // so that we can verify the fallback default values for the other variables.
 putenv('DB_HOST'); putenv('DB_USER'); putenv('DB_PASS=dummy'); putenv('DB_NAME');
 try { @include __DIR__ . '/../conf/config.php'; } catch (Exception $e) {}
-if ($dbhost !== 'localhost' || $dbuser !== 'root' || $dbpass !== 'dummy' || $dbname !== 'test') {
+if ($dbhost !== 'localhost' || $dbuser !== '' || $dbpass !== 'dummy' || $dbname !== 'test') {
     echo "FAIL: Expected defaults.\n";
     $failed = true;
 }


### PR DESCRIPTION
🎯 What:
Changed the fallback default database user in `conf/config.php` from `'root'` to `''`. Also updated the corresponding test in `tests/test_config.php` to reflect this new default.

⚠️ Risk:
Leaving `'root'` as the default database user could unintentionally allow highly privileged access to the database if the `DB_USER` environment variable is misconfigured, missing, or drops. This violates the principle of least privilege and presents a significant security risk, especially in production environments where the default root user might not have a password or uses a known default password.

🛡️ Solution:
Replaced the default fallback `'root'` with an empty string `''`. This ensures that if no database user is provided, the connection attempt will fail securely (due to missing credentials) rather than silently succeeding with superuser privileges.

---
*PR created automatically by Jules for task [2187621940813734080](https://jules.google.com/task/2187621940813734080) started by @cahyadsn*