### PR TITLE
🧪 [testing improvement] Add missing Error Log Test in index.php

### DIFF
--- a/tests/README.md
+++ b/tests/README.md
@@ -36,6 +36,7 @@ php tests/test_exception_leak.php
 php tests/test_sqli_fix.php
 php tests/test_lazy_db.php
 php tests/test_index_query_failure.php
+php tests/test_index_error_log.php
 php tests/test_caching_performance.php
 php tests/test_security_headers.php
 php tests/test_result_fallback.php
@@ -64,6 +65,7 @@ php tests/test_autoload_env.php
 | `test_sqli_fix.php` | Verifikasi `result.php` menggunakan prepared statements (`bind_param`) bukan string concatenation |
 | `test_lazy_db.php` | Test bahwa koneksi database tidak dilakukan saat cache HTML tersedia |
 | `test_index_query_failure.php` | Test bahwa `index.php` menampilkan pesan error ketika query database gagal |
+| `test_index_error_log.php` | Verifikasi bahwa error koneksi database di `index.php` di-log menggunakan `error_log()` |
 | `test_caching_performance.php` | Benchmark perbandingan performa antara query DB (mock) dan file cache |
 | `test_security_headers.php` | Verifikasi `index.php` and `result.php` mengirim security headers (`X-Frame-Options`, `X-Content-Type-Options`) |
 | `test_result_fallback.php` | Test fallback pada `result.php`; verifikasi parameter default (15, 14, 15, 14) terikat dengan benar dalam single-execute query |

--- a/tests/test_index_error_log.php
+++ b/tests/test_index_error_log.php
@@ -1,0 +1,28 @@
+<?php
+$log_file = __DIR__ . '/test_index_error.log';
+@unlink($log_file);
+ini_set('error_log', $log_file);
+
+putenv('DB_HOST=invalid_host_12345');
+putenv('DB_USER=test');
+putenv('DB_PASS=dummy');
+putenv('DB_NAME=test');
+
+$cache_file = __DIR__ . '/../cache/html_cache.html';
+@unlink($cache_file);
+
+ob_start();
+// Suppress warnings from mysqli connection failures if any leak through
+@include __DIR__ . '/../index.php';
+$output = ob_get_clean();
+
+$log_contents = @file_get_contents($log_file);
+@unlink($log_file);
+
+if ($log_contents && strpos($log_contents, "Database connection failed.") !== false) {
+    echo "PASS: error_log called with connection failure message in index.php.\n";
+    exit(0);
+} else {
+    echo "FAIL: error_log was not called with expected message in index.php. Log contents: " . ($log_contents ?: 'empty') . "\n";
+    exit(1);
+}


### PR DESCRIPTION
🎯 **What:** Added a test to verify that connection failures occurring when `index.php` includes `config.php` are properly caught and logged via `error_log()`.

📊 **Coverage:** The new test `tests/test_index_error_log.php` covers the try-catch block for `config.php` inclusion in `index.php`, simulating an invalid database host and intercepting the output to a custom error log.

✨ **Result:** Test coverage for `index.php` is increased, ensuring that database connection exceptions are safely caught and logged without leaking to the user.

---
*PR created automatically by Jules for task [13869605073201404437](https://jules.google.com/task/13869605073201404437) started by @cahyadsn*