### PR TITLE
🧹 [code health improvement] Remove error suppression from file_put_contents

### DIFF
--- a/index.php
+++ b/index.php
@@ -152,7 +152,7 @@ if ($html_content === false) {
       echo implode('', $html);
     $html_content = ob_get_clean();
     if ($result) {
-        if (@file_put_contents($html_cache_file, $html_content, LOCK_EX) === false) {
+        if (file_put_contents($html_cache_file, $html_content, LOCK_EX) === false) {
             error_log("Failed to write to HTML cache file: $html_cache_file");
         }
     }


### PR DESCRIPTION
🎯 **What:** Removed the `@` error suppression operator from the `file_put_contents` call in `index.php`.

💡 **Why:** Suppressing errors with `@` makes debugging extremely difficult and hides native system warnings (like directory permission issues) that could provide valuable context. The codebase already properly handles the failure by checking for a `false` return value and manually logging an error via `error_log()`. Relying on the false return value while allowing standard warnings to surface (or be caught by standard error handlers) improves transparency and maintainability.

✅ **Verification:** Verified by running the existing full test suite (including `test_html_cache_write_failure.php` which tests this exact path). The test correctly asserts that when `file_put_contents` fails, it logs the appropriate message and no fatal errors occur, verifying that the fix is completely safe.

✨ **Result:** Enhanced code health and standard error reporting reliability without changing expected failure fallback behaviors.

---
*PR created automatically by Jules for task [12226843617274999044](https://jules.google.com/task/12226843617274999044) started by @cahyadsn*