### PR TITLE
🔒 Fix: Add missing Strict-Transport-Security (HSTS) header

### DIFF
--- a/conf/headers.php
+++ b/conf/headers.php
@@ -7,6 +7,7 @@ if (empty($_SESSION['csrf_token'])) {
 }
 
 if (!headers_sent()) {
+    header('Strict-Transport-Security: max-age=31536000; includeSubDomains');
     header('X-Frame-Options: DENY');
     header('X-Content-Type-Options: nosniff');
     header("Content-Security-Policy: default-src 'self';");

--- a/tests/test_security_headers.php
+++ b/tests/test_security_headers.php
@@ -1,6 +1,10 @@
 <?php
 $passed = true;
 $header_content = file_get_contents(__DIR__ . '/../conf/headers.php');
+if (strpos($header_content, "header('Strict-Transport-Security: max-age=31536000; includeSubDomains');") === false) {
+    echo "Missing Strict-Transport-Security in conf/headers.php\n";
+    $passed = false;
+}
 if (strpos($header_content, "header('X-Frame-Options: DENY');") === false) {
     echo "Missing X-Frame-Options in conf/headers.php\n";
     $passed = false;


### PR DESCRIPTION
🎯 What
Added the missing `Strict-Transport-Security` (HSTS) header to `conf/headers.php` with a standard `max-age=31536000` and `includeSubDomains`. Updated `tests/test_security_headers.php` to verify its presence via static analysis.

⚠️ Risk
Without HSTS, the application is vulnerable to protocol downgrade attacks and cookie hijacking. Attackers could potentially intercept unencrypted HTTP connections and perform man-in-the-middle attacks before the browser redirects to HTTPS.

🛡️ Solution
Configured the HSTS header natively in PHP within the existing security headers block. This forces browsers to strictly interact with the domain (and subdomains) over HTTPS for a period of one year, mitigating downgrade risks.

---
*PR created automatically by Jules for task [13510255945369475063](https://jules.google.com/task/13510255945369475063) started by @cahyadsn*