### PR TITLE
🔒 Fix session cookie security flags (secure and httponly)

### DIFF
--- a/conf/headers.php
+++ b/conf/headers.php
@@ -1,5 +1,7 @@
 <?php
 if (session_status() === PHP_SESSION_NONE) {
+    ini_set('session.cookie_secure', '1');
+    ini_set('session.cookie_httponly', '1');
     session_start();
 }
 if (empty($_SESSION['csrf_token'])) {

--- a/tests/test_session_cookies.php
+++ b/tests/test_session_cookies.php
@@ -1,0 +1,18 @@
+<?php
+$passed = true;
+$header_content = file_get_contents(__DIR__ . '/../conf/headers.php');
+if (strpos($header_content, "ini_set('session.cookie_secure', '1');") === false) {
+    echo "Missing session.cookie_secure in conf/headers.php\n";
+    $passed = false;
+}
+if (strpos($header_content, "ini_set('session.cookie_httponly', '1');") === false) {
+    echo "Missing session.cookie_httponly in conf/headers.php\n";
+    $passed = false;
+}
+if ($passed) {
+    echo "Session cookies test passed.\n";
+    exit(0);
+} else {
+    echo "Session cookies test failed.\n";
+    exit(1);
+}


### PR DESCRIPTION
🎯 **What:** Set `session.cookie_secure` and `session.cookie_httponly` to `1` in `conf/headers.php`.

⚠️ **Risk:** Without these flags, session cookies are vulnerable to XSS attacks (as they can be read by JavaScript) and can be transmitted over unencrypted HTTP connections, allowing attackers to intercept or steal session tokens and hijack user sessions.

🛡️ **Solution:** Implemented `ini_set` for both `session.cookie_secure` and `session.cookie_httponly` flags before the `session_start()` call. This enforces that the browser will only send the session cookie over HTTPS, and that client-side scripts cannot access the cookie. A test was also added to ensure these directives are present.

---
*PR created automatically by Jules for task [12459920072928423771](https://jules.google.com/task/12459920072928423771) started by @cahyadsn*