### PR TITLE
🔒 Fix overly restrictive CSP breaking external fonts

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,7 +70,7 @@ This project is built using a lightweight and highly optimized architecture desi
   * **Loop & Memory Optimizations**: Minimized array allocations and nested calculations inside loops.
 * **Security & Hardening**:
   * **CSRF Protection**: Form submissions on `index.php` are protected against Cross-Site Request Forgery (CSRF) via session-backed, cryptographically secure random tokens validated with `hash_equals()` in `result.php`.
-  * **HTTP Security Headers**: Implements custom protection rules such as `X-Frame-Options: DENY`, `X-Content-Type-Options: nosniff`, and a restrictive `Content-Security-Policy: default-src 'self';` to defend against clickjacking, MIME sniffing, and cross-site scripting (XSS).
+  * **HTTP Security Headers**: Implements custom protection rules such as `X-Frame-Options: DENY`, `X-Content-Type-Options: nosniff`, and a restrictive `Content-Security-Policy: default-src 'self'; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com; font-src 'self' https://fonts.gstatic.com;` to defend against clickjacking, MIME sniffing, and cross-site scripting (XSS).
   * **XSS Defenses**: Sanitized and escaped HTML output using `htmlspecialchars` with UTF-8 encoding.
   * **Sensitive Data Redaction**: Safe exception handling prevents database password and credential leaks in debug logs and user interfaces by stripping underlying exception context during connection failures.
 * **Frontend & Presentation**:
@@ -208,7 +208,7 @@ This project is built using a lightweight and highly optimized architecture desi
 ### Recent Updates (2026-07-26)
 - **Security & Caching**:
   - Moved `html_cache.html` out of the web root into the local `cache/` directory (protected via `.htaccess`) to prevent direct public HTTP access.
-  - Implemented `Content-Security-Policy: default-src 'self';` header on both `index.php` and `result.php`.
+  - Implemented `Content-Security-Policy: default-src 'self'; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com; font-src 'self' https://fonts.gstatic.com;` header on both `index.php` and `result.php`.
   - Redacted the database connection exception context (stripped internal PHP exception chains) to prevent accidental database credential leaks in debug logs.
   - Removed redundant `file_exists()` checks before checking `is_readable()` when resolving HTML cache hits.
 

--- a/conf/headers.php
+++ b/conf/headers.php
@@ -9,5 +9,5 @@ if (empty($_SESSION['csrf_token'])) {
 if (!headers_sent()) {
     header('X-Frame-Options: DENY');
     header('X-Content-Type-Options: nosniff');
-    header("Content-Security-Policy: default-src 'self';");
+    header("Content-Security-Policy: default-src 'self'; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com; font-src 'self' https://fonts.gstatic.com;");
 }

--- a/tests/test_security_headers.php
+++ b/tests/test_security_headers.php
@@ -9,7 +9,7 @@ if (strpos($header_content, "header('X-Content-Type-Options: nosniff');") === fa
     echo "Missing X-Content-Type-Options in conf/headers.php\n";
     $passed = false;
 }
-if (strpos($header_content, "header(\"Content-Security-Policy: default-src 'self';\");") === false) {
+if (strpos($header_content, "header(\"Content-Security-Policy: default-src 'self'; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com; font-src 'self' https://fonts.gstatic.com;\");") === false) {
     echo "Missing Content-Security-Policy in conf/headers.php\n";
     $passed = false;
 }


### PR DESCRIPTION
🎯 **What:** Updated the Content-Security-Policy header in `conf/headers.php` to include `style-src` allowing `'unsafe-inline'` and `https://fonts.googleapis.com`, and `font-src` allowing `https://fonts.gstatic.com`.
⚠️ **Risk:** The previous CSP was too restrictive, preventing the application from loading necessary external fonts (Google Fonts) and inline styles which are actively used throughout `index.php` and `result.php`. This degraded the intended User Experience (UX) and visual design without providing meaningful additional security, as script execution and core data exfiltration vectors are still mitigated by the existing `default-src 'self'`.
🛡️ **Solution:** Carefully relaxed the `style-src` and `font-src` directives to explicitly allow the required Google Fonts domains and inline styles, while maintaining the restrictive `default-src 'self'` for other resource types like scripts and frames. Updated static analysis security tests and the README.md file to reflect the new CSP baseline.

---
*PR created automatically by Jules for task [12895173943563439925](https://jules.google.com/task/12895173943563439925) started by @cahyadsn*